### PR TITLE
Add mockup carousel and swap fix

### DIFF
--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -36,6 +36,7 @@ from flask import (
     flash,
     send_from_directory,
     Response,
+    jsonify,
 )
 import re
 
@@ -501,10 +502,36 @@ def review_regenerate_mockup(aspect, filename, slot_idx):
 @bp.route("/review/<seo_folder>/swap/<int:slot_idx>", methods=["POST"])
 def review_swap_mockup(seo_folder, slot_idx):
     new_cat = request.form["new_category"]
-    if not utils.swap_one_mockup(seo_folder, slot_idx, new_cat):
-        flash("Failed to swap mockup", "danger")
+    success = utils.swap_one_mockup(seo_folder, slot_idx, new_cat)
 
     info = utils.find_aspect_filename_from_seo_folder(seo_folder)
+
+    if request.headers.get("X-Requested-With") == "XMLHttpRequest" or request.accept_mimetypes.best == "application/json":
+        img_url = ""
+        if success and info:
+            aspect, _filename = info
+            folder = utils.ARTWORK_PROCESSED_DIR / seo_folder
+            listing = folder / f"{seo_folder}-listing.json"
+            if not listing.exists():
+                folder = utils.FINALISED_DIR / seo_folder
+                listing = folder / f"{seo_folder}-listing.json"
+            try:
+                with open(listing, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                mp = data.get("mockups", [])[slot_idx]
+                if isinstance(mp, dict):
+                    comp = mp.get("composite")
+                    if comp:
+                        img_url = url_for(
+                            "artwork.processed_image", seo_folder=seo_folder, filename=comp
+                        )
+            except Exception:  # noqa: BLE001
+                img_url = ""
+        return jsonify({"success": success, "img_url": img_url})
+
+    if not success:
+        flash("Failed to swap mockup", "danger")
+
     if info:
         aspect, filename = info
         return redirect(url_for("artwork.edit_listing", aspect=aspect, filename=filename))

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,69 @@
+/* =====================================
+   ArtNarrator Custom Styles
+   ===================================== */
+
+/* --------- [ C1. Modal Carousel ] --------- */
+:root {
+  --modal-overlay-bg: rgba(34,34,34,0.68);
+}
+
+.modal-bg {
+  display: none;
+  position: fixed;
+  z-index: 99;
+  left: 0; top: 0;
+  width: 100vw; height: 100vh;
+  background: var(--modal-overlay-bg);
+  align-items: center;
+  justify-content: center;
+}
+.modal-bg.active { display: flex !important; }
+
+.modal-img {
+  background: transparent !important;
+  border-radius: 0 !important;
+  padding: 0 !important;
+  max-width: 94vw;
+  max-height: 93vh;
+  box-shadow: 0 5px 26px rgba(0,0,0,0.22);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.modal-img img {
+  max-width: 88vw;
+  max-height: 80vh;
+  border-radius: 0 !important;
+  border: none !important;
+  background: none !important;
+  display: block;
+  box-shadow: none !important;
+}
+.modal-close {
+  position: absolute;
+  top: 2.3vh;
+  right: 2.6vw;
+  font-size: 2em;
+  color: var(--color-btn-text);
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 101;
+  text-shadow: 0 2px 6px #000;
+}
+.modal-close:focus {
+  outline: 2px solid #ffe873;
+}
+.carousel-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  color: var(--color-btn-text);
+  font-size: 2.5em;
+  cursor: pointer;
+  padding: 0 0.2em;
+}
+#carousel-prev { left: 1vw; }
+#carousel-next { right: 1vw; }

--- a/static/js/edit_listing.js
+++ b/static/js/edit_listing.js
@@ -1,0 +1,87 @@
+/* ==============================
+   ArtNarrator Edit Listing JS
+   ============================== */
+
+/* --------- [ EL1. Carousel Modal ] --------- */
+document.addEventListener('DOMContentLoaded', () => {
+  const carousel = document.getElementById('mockup-carousel');
+  const imgEl = document.getElementById('carousel-img');
+  const closeBtn = document.getElementById('carousel-close');
+  const prevBtn = document.getElementById('carousel-prev');
+  const nextBtn = document.getElementById('carousel-next');
+
+  const links = Array.from(document.querySelectorAll('.mockup-img-link'));
+  const thumb = document.querySelector('.main-thumb-link');
+  if (thumb) links.unshift(thumb);
+  const images = links.map(l => l.dataset.img);
+  let idx = 0;
+
+  function show(i) {
+    idx = (i + images.length) % images.length;
+    imgEl.src = images[idx];
+    carousel.classList.add('active');
+  }
+  function close() {
+    carousel.classList.remove('active');
+    imgEl.src = '';
+  }
+  links.forEach((link, i) => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      show(i);
+    });
+  });
+  if (closeBtn) closeBtn.onclick = close;
+  if (prevBtn) prevBtn.onclick = () => show(idx - 1);
+  if (nextBtn) nextBtn.onclick = () => show(idx + 1);
+  if (carousel) carousel.addEventListener('click', e => { if (e.target === carousel) close(); });
+  document.addEventListener('keydown', e => {
+    if (!carousel.classList.contains('active')) return;
+    if (e.key === 'Escape') close();
+    else if (e.key === 'ArrowLeft') show(idx - 1);
+    else if (e.key === 'ArrowRight') show(idx + 1);
+  });
+
+  /* --------- [ EL2. Swap Mockup Forms ] --------- */
+  document.querySelectorAll('.swap-form').forEach(form => {
+    form.addEventListener('submit', ev => {
+      ev.preventDefault();
+      const sel = form.querySelector('select[name="new_category"]');
+      const data = new FormData();
+      data.append('new_category', sel.value);
+      fetch(form.action, {
+        method: 'POST',
+        body: data,
+        headers: { 'X-Requested-With': 'XMLHttpRequest' }
+      })
+      .then(r => r.json())
+      .then(d => {
+        if (d.success && d.img_url) {
+          const card = form.closest('.mockup-card');
+          const img = card.querySelector('.mockup-thumb-img');
+          if (img) img.src = d.img_url + '?t=' + Date.now();
+          const link = card.querySelector('.mockup-img-link');
+          if (link) {
+            link.href = d.img_url;
+            link.dataset.img = d.img_url;
+          }
+        } else {
+          window.location.reload();
+        }
+      })
+      .catch(() => window.location.reload());
+    });
+  });
+
+  /* --------- [ EL3. Enable Action Buttons ] --------- */
+  function toggleActionBtns() {
+    const txt = document.querySelector('textarea[name="images"]');
+    const disabled = !(txt && txt.value.trim());
+    document.querySelectorAll('.require-images').forEach(btn => {
+      btn.disabled = disabled;
+    });
+  }
+  const imagesTextarea = document.querySelector('textarea[name="images"]');
+  if (imagesTextarea) imagesTextarea.addEventListener('input', toggleActionBtns);
+  toggleActionBtns();
+});

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -168,57 +168,5 @@
 </div>
 
 
-<script>
-  document.addEventListener('DOMContentLoaded', function() {
-    const carousel = document.getElementById('mockup-carousel');
-    const imgEl = document.getElementById('carousel-img');
-    const closeBtn = document.getElementById('carousel-close');
-    const prevBtn = document.getElementById('carousel-prev');
-    const nextBtn = document.getElementById('carousel-next');
-
-    const links = Array.from(document.querySelectorAll('.mockup-img-link'));
-    const thumb = document.querySelector('.main-thumb-link');
-    if (thumb) links.unshift(thumb);
-    const images = links.map(l => l.dataset.img);
-    let idx = 0;
-
-    function show(i) {
-      idx = (i + images.length) % images.length;
-      imgEl.src = images[idx];
-      carousel.classList.add('active');
-    }
-
-    function close() {
-      carousel.classList.remove('active');
-      imgEl.src = '';
-    }
-
-    links.forEach((link, i) => {
-      link.addEventListener('click', e => {
-        e.preventDefault();
-        show(i);
-      });
-    });
-
-    if (closeBtn) closeBtn.onclick = close;
-    if (prevBtn) prevBtn.onclick = () => show(idx - 1);
-    if (nextBtn) nextBtn.onclick = () => show(idx + 1);
-    if (carousel) carousel.addEventListener('click', e => { if (e.target === carousel) close(); });
-    document.addEventListener('keydown', e => {
-      if (!carousel.classList.contains('active')) return;
-      if (e.key === 'Escape') close();
-      else if (e.key === 'ArrowLeft') show(idx - 1);
-      else if (e.key === 'ArrowRight') show(idx + 1);
-    });
-
-    function toggleActionBtns() {
-      const txt = document.querySelector('textarea[name="images"]');
-      const disabled = !(txt && txt.value.trim());
-      document.querySelectorAll('.require-images').forEach(btn => { btn.disabled = disabled; });
-    }
-    const imagesTextarea = document.querySelector('textarea[name="images"]');
-    if (imagesTextarea) imagesTextarea.addEventListener('input', toggleActionBtns);
-    toggleActionBtns();
-  });
-</script>
+<script src="{{ url_for('static', filename='js/edit_listing.js') }}"></script>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -11,6 +11,7 @@
   </script>
   <title>{% block title %}ArtNarrator{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
 <body>
   <!-- ========== [MA.1] Top Navigation ========== -->


### PR DESCRIPTION
## Summary
- fix swap endpoint to support Ajax updates
- add edit listing JavaScript for carousel modal and swap forms
- style carousel via new `custom.css`
- load `custom.css` sitewide and include external script for edit page

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687882e3c7b0832e9a97ca4df9fee410