### PR TITLE
Add step icons and hero icons

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -230,3 +230,47 @@
     margin-bottom: 16px;
   }
 }
+
+/* --------- [ Workflow Step Icons ] --------- */
+.step-btn-icon {
+  width: 35px;
+  height: 35px;
+  margin-right: 12px;
+  vertical-align: middle;
+  display: inline-block;
+}
+
+.hero-step-icon {
+  width: 100px;
+  height: 100px;
+  vertical-align: middle;
+  margin-right: 28px;
+  display: inline-block;
+}
+
+.theme-light .hero-step-icon {
+  filter: invert(1) grayscale(1) brightness(1.5);
+}
+.theme-dark .hero-step-icon {
+  filter: none;
+}
+
+.workflow-btn {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  font-family: monospace !important;
+  font-size: 1.25rem;
+  font-weight: bold;
+  padding: 18px 32px;
+  background: var(--color-accent, #e76a25);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  min-width: 220px;
+  margin: 0 16px 0 0;
+  transition: background 0.2s;
+}
+
+
+.workflow-btn.disabled{background:#ccc;color:#666;pointer-events:none;}

--- a/templates/artworks.html
+++ b/templates/artworks.html
@@ -3,6 +3,11 @@
 {% block title %}Artwork Gallery | ArtNarrator{% endblock %}
 {% block content %}
 
+<div class="page-title-row" style="display: flex; align-items: center; margin-bottom: 40px;">
+  <img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="hero-step-icon" alt="Step 2: Art Gallery" />
+  <h1>Art Gallery</h1>
+</div>
+
 <div class="gallery-section">
 
   {% if ready_artworks %}

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -44,7 +44,10 @@
 
   <!-- === Edit Fields Column === -->
   <div class="edit-listing-col">
-    <h1>Edit Listing</h1>
+    <div class="page-title-row" style="display: flex; align-items: center; margin-bottom: 40px;">
+      <img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="hero-step-icon" alt="Step 3: Edit Listing" />
+      <h1>Edit Listing</h1>
+    </div>
     <!-- Status at Top -->
     <p class="status-line {% if finalised %}status-finalised{% else %}status-pending{% endif %}">
       Status: This artwork is {% if finalised %}<strong>finalised</strong>{% else %}<em>NOT yet finalised</em>{% endif %}

--- a/templates/finalised.html
+++ b/templates/finalised.html
@@ -2,7 +2,10 @@
 {% extends "main.html" %}
 {% block title %}Finalised Artworks{% endblock %}
 {% block content %}
-<h1>Finalised Artworks</h1>
+<div class="page-title-row" style="display: flex; align-items: center; margin-bottom: 40px;">
+  <img src="{{ url_for('static', filename='icons/svg/light/number-circle-four-light.svg') }}" class="hero-step-icon" alt="Step 4: Finalised" />
+  <h1>Finalised Artworks</h1>
+</div>
 <p class="help-tip">Finalised artworks are ready for publishing or exporting to Sellbrite. You can still edit or delete them here.</p>
 <div class="view-toggle">
   <button id="grid-view-btn" class="btn-small">Grid</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,15 +13,33 @@
 
 <!-- ========== [IN.2] Home Quick Actions ========== -->
 <div class="workflow-grid">
-  <a href="{{ url_for('artwork.upload_artwork') }}" class="step-btn">1️⃣ Upload<br>to Art Gallery</a>
-  <a href="{{ url_for('artwork.artworks') }}" class="step-btn">2️⃣ Art Gallery<br>Select to Analyze</a>
+  <a href="{{ url_for('artwork.upload_artwork') }}" class="workflow-btn">
+    <img src="{{ url_for('static', filename='icons/svg/light/number-circle-one-light.svg') }}" class="step-btn-icon" alt="Step 1" />
+    Upload<br>to Art Gallery
+  </a>
+  <a href="{{ url_for('artwork.artworks') }}" class="workflow-btn">
+    <img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="step-btn-icon" alt="Step 2" />
+    Art Gallery<br>Select to Analyze
+  </a>
   {% if latest_artwork %}
-    <a href="{{ url_for('artwork.edit_listing', aspect=latest_artwork.aspect, filename=latest_artwork.filename) }}" class="step-btn">3️⃣ Edit Review<br>and Finalise Artwork</a>
+    <a href="{{ url_for('artwork.edit_listing', aspect=latest_artwork.aspect, filename=latest_artwork.filename) }}" class="workflow-btn">
+      <img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="step-btn-icon" alt="Step 3" />
+      Edit Review<br>and Finalise Artwork
+    </a>
   {% else %}
-    <span class="step-btn disabled">3️⃣ Edit Review<br>and Finalise Artwork</span>
+    <span class="workflow-btn disabled">
+      <img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="step-btn-icon" alt="Step 3" />
+      Edit Review<br>and Finalise Artwork
+    </span>
   {% endif %}
-  <a href="{{ url_for('artwork.finalised_gallery') }}" class="step-btn">4️⃣ Finalised Gallery<br>(Select to List)</a>
-  <span class="step-btn disabled">5️⃣ List Artwork<br>(Export to Sellbrite)</span>
+  <a href="{{ url_for('artwork.finalised_gallery') }}" class="workflow-btn">
+    <img src="{{ url_for('static', filename='icons/svg/light/number-circle-four-light.svg') }}" class="step-btn-icon" alt="Step 4" />
+    Finalised Gallery<br>(Select to List)
+  </a>
+  <span class="workflow-btn disabled">
+    <img src="{{ url_for('static', filename='icons/svg/light/number-circle-five-light.svg') }}" class="step-btn-icon" alt="Step 5" />
+    List Artwork<br>(Export to Sellbrite)
+  </span>
 </div>
 
 <!-- ========== [IN.3] How It Works Section ========== -->

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,7 +1,10 @@
 {% extends "main.html" %}
 {% block title %}Upload Artwork{% endblock %}
 {% block content %}
-<h2 class="mb-3">Upload New Artwork</h2>
+<div class="page-title-row" style="display: flex; align-items: center; margin-bottom: 40px;">
+  <img src="{{ url_for('static', filename='icons/svg/light/number-circle-one-light.svg') }}" class="hero-step-icon" alt="Step 1: Upload" />
+  <h1>Upload New Artwork</h1>
+</div>
 <form id="upload-form" method="post" enctype="multipart/form-data">
   <input id="file-input" type="file" name="images" accept="image/*" multiple hidden>
   <div id="dropzone" class="upload-dropzone">


### PR DESCRIPTION
## Summary
- style step icons with new CSS classes
- add numeric icons to workflow buttons
- show hero step icon next to page titles

## Testing
- `pytest -q tests` *(fails: StopIteration)*

------
https://chatgpt.com/codex/tasks/task_e_68789b22c060832e9573586a966a8fbb