### PR TITLE
Mobile footer and security

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from flask import Flask, render_template, request, redirect, url_for, session
+from utils import security
 from werkzeug.routing import BuildError
 from dotenv import load_dotenv
 from datetime import datetime
@@ -16,6 +17,7 @@ from routes.artwork_routes import bp as artwork_bp  # <-- Blueprint import
 from routes.sellbrite_service import bp as sellbrite_bp
 from routes.export_routes import bp as exports_bp
 from routes.auth_routes import bp as auth_bp
+from routes.admin_security import bp as admin_bp
 
 # ---- Load .env Configuration ----
 load_dotenv()
@@ -31,7 +33,7 @@ def require_login() -> None:
     allowed = {"auth.login", "static"}
     if request.endpoint in allowed or request.endpoint is None:
         return
-    if not session.get("logged_in"):
+    if security.login_required_enabled() and not session.get("logged_in"):
         return redirect(url_for("auth.login", next=request.path))
 
 # ---- Logging Setup ----
@@ -67,6 +69,7 @@ app.register_blueprint(auth_bp)
 app.register_blueprint(artwork_bp)
 app.register_blueprint(sellbrite_bp)
 app.register_blueprint(exports_bp)
+app.register_blueprint(admin_bp)
 
 # ---- Error Handlers ----
 @app.errorhandler(BuildError)

--- a/routes/admin_security.py
+++ b/routes/admin_security.py
@@ -1,0 +1,35 @@
+"""Admin security routes for toggling login requirement."""
+from __future__ import annotations
+
+from flask import Blueprint, render_template, request, redirect, url_for, session
+from datetime import datetime
+
+from utils import security
+
+bp = Blueprint("admin", __name__, url_prefix="/admin")
+
+
+def is_admin() -> bool:
+    return session.get("username") == "robbie"
+
+
+@bp.route("/security", methods=["GET", "POST"])
+def security_page():
+    if not session.get("logged_in") or not is_admin():
+        return redirect(url_for("auth.login", next=request.path))
+    if request.method == "POST":
+        action = request.form.get("action")
+        if action == "enable":
+            security.enable_login()
+        elif action == "disable":
+            minutes = int(request.form.get("minutes", 5))
+            security.disable_login_for(minutes)
+        return redirect(url_for("admin.security_page"))
+    remaining = security.remaining_minutes()
+    login_required = security.login_required_enabled()
+    return render_template(
+        "admin/security.html",
+        login_required=login_required,
+        remaining=remaining,
+        expires=security.load_settings().get("expires"),
+    )

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+from utils import security
 from dotenv import load_dotenv
 import config
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -204,16 +204,14 @@
 
 /* --- Footer Styling --- */
 .site-footer {
-  position: fixed;
-  left: 0; right: 0; bottom: 0;
-  width: 100vw;
+  width: 100%;
   min-height: 150px;
   background: var(--color-footer-bg, #000);
   color: var(--color-footer-text, #fff);
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  z-index: 999;
+  margin-top: auto;
 }
 
 .footer-menu-bar {
@@ -326,3 +324,20 @@
   font-size: 1em;
   border: 1px solid var(--color-border);
 }
+
+/* --- Admin Security Panel --- */
+.security-panel { max-width: 420px; margin: 2em auto; padding: 1.5em; background: var(--color-card-bg); box-shadow: 0 2px 6px rgba(0,0,0,0.15); text-align:center; }
+.security-panel form { margin-top:1em; display:flex; flex-direction:column; gap:1em; }
+.security-panel select{ padding:0.4em; }
+
+
+body { display:flex; flex-direction:column; min-height:100vh; }
+main { flex:1 0 auto; }
+
+.footer-inner{max-width:1200px;margin:0 auto;padding:1em;display:flex;flex-direction:column;}
+.footer-nav{display:flex;gap:2em;flex-wrap:wrap;}
+.footer-nav a{color:#fff;text-decoration:none;}
+.footer-nav a:hover{color:#e76a25;}
+.footer-copy{text-align:left;margin-top:auto;color:#fff;}
+@media(max-width:600px){.footer-nav{flex-direction:column;gap:1em;}}
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -470,12 +470,12 @@ input:focus, textarea:focus { border-color: var(--accent); }
 @media (max-width: 1200px) {
   .review-artwork-grid { max-width: 98vw; }
 }
-@media (max-width: 900px) {
+@media (max-width: 800px) {
   .review-artwork-grid { flex-direction: column; gap: 2em; }
   .mockup-col, .desc-col { max-width: 100%; min-width: 0; }
   .mockup-preview-grid { grid-template-columns: repeat(2,1fr); }
 }
-@media (max-width: 800px) {
+@media (max-width: 700px) {
   .mockup-preview-grid { grid-template-columns: 1fr; }
   .edit-actions-col button,
   .edit-actions-col form { width: 100%; }

--- a/templates/admin/security.html
+++ b/templates/admin/security.html
@@ -1,0 +1,25 @@
+{% extends "main.html" %}
+{% block title %}Security Settings{% endblock %}
+{% block content %}
+<h1>Site Security</h1>
+<div class="security-panel">
+  <p>Login required: <strong>{{ 'ON' if login_required else 'OFF' }}</strong></p>
+  {% if remaining %}
+  <p>Login will re-enable in {{ remaining }} minute{{ 's' if remaining != 1 else '' }}.</p>
+  {% endif %}
+  <form method="post">
+    {% if login_required %}
+      <label for="minutes">Disable for:</label>
+      <select name="minutes" id="minutes">
+        <option value="5">5 min</option>
+        <option value="20">20 min</option>
+        <option value="60">1 hr</option>
+        <option value="120">2 hr</option>
+      </select>
+      <button type="submit" name="action" value="disable" class="btn btn-primary">Disable Login</button>
+    {% else %}
+      <button type="submit" name="action" value="enable" class="btn btn-primary">Re-enable Now</button>
+    {% endif %}
+  </form>
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,6 +6,7 @@
   {% with msgs = get_flashed_messages(with_categories=true) %}
     {% if msgs %}
       <div class="flash">
+        <img src="{{ url_for('static', filename='icons/svg/light/warning-circle-light.svg') }}" alt="!" style="width:20px;margin-right:6px;vertical-align:middle;">
         {% for cat, msg in msgs %}
           {{ msg }}
         {% endfor %}

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -4,6 +4,9 @@
       <a href="{{ url_for('artwork.home') }}">Home</a>
       <a href="{{ url_for('artwork.artworks') }}">Gallery</a>
       <a href="{{ url_for('exports.sellbrite_exports') }}">Exports</a>
+      {% if session.get('username') == 'robbie' %}
+        <a href="{{ url_for('admin.security_page') }}">Security</a>
+      {% endif %}
     </nav>
     <div class="footer-copy">&copy; 2025 ArtNarrator</div>
   </div>

--- a/templates/partials/topnav.html
+++ b/templates/partials/topnav.html
@@ -6,6 +6,9 @@
     <a href="{{ url_for('artwork.finalised_gallery') }}">Finalised</a>
     <a href="{{ url_for('artwork.locked_gallery') }}">Locked</a>
     <a href="{{ url_for('exports.sellbrite_exports') }}">Exports</a>
+    {% if session.get('username') == 'robbie' %}
+      <a href="{{ url_for('admin.security_page') }}">Security</a>
+    {% endif %}
     <div class="user-links">
       {% if session.get('logged_in') %}
         <span class="user-name">{{ session.get('username') }}</span>

--- a/utils/security.py
+++ b/utils/security.py
@@ -1,0 +1,59 @@
+"""Utility helpers for login requirement toggle."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from datetime import datetime, timedelta
+
+SETTINGS_FILE = Path("settings/security_settings.json")
+
+DEFAULTS = {"login_required": True, "expires": None}
+
+
+def load_settings() -> dict:
+    if SETTINGS_FILE.exists():
+        try:
+            return json.loads(SETTINGS_FILE.read_text())
+        except Exception:
+            pass
+    SETTINGS_FILE.write_text(json.dumps(DEFAULTS))
+    return DEFAULTS.copy()
+
+
+def save_settings(data: dict) -> None:
+    SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SETTINGS_FILE.write_text(json.dumps(data))
+
+
+def login_required_enabled() -> bool:
+    data = load_settings()
+    if not data.get("login_required"):
+        exp = data.get("expires")
+        if exp and datetime.fromisoformat(exp) <= datetime.utcnow():
+            data["login_required"] = True
+            data["expires"] = None
+            save_settings(data)
+    return data.get("login_required", True)
+
+
+def disable_login_for(minutes: int) -> None:
+    data = load_settings()
+    data["login_required"] = False
+    data["expires"] = (datetime.utcnow() + timedelta(minutes=minutes)).isoformat()
+    save_settings(data)
+
+
+def enable_login() -> None:
+    data = load_settings()
+    data["login_required"] = True
+    data["expires"] = None
+    save_settings(data)
+
+
+def remaining_minutes() -> int | None:
+    data = load_settings()
+    exp = data.get("expires")
+    if exp:
+        delta = datetime.fromisoformat(exp) - datetime.utcnow()
+        return max(int(delta.total_seconds() // 60), 0)
+    return None


### PR DESCRIPTION
## Summary
- tweak mobile styles for edit listing layout
- refactor footer to always stay at the bottom
- add login security toggle with admin page

## Testing
- `PYTHONPATH=$(pwd) pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_6878ebe0c0f8832e986d2c948fce46c9