### PR TITLE
Enable multi-device login sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from flask import Flask, render_template, request, redirect, url_for, session
-from utils import security
+from utils import security, session_tracker
 from werkzeug.routing import BuildError
 from dotenv import load_dotenv
 from datetime import datetime
@@ -33,8 +33,16 @@ def require_login() -> None:
     allowed = {"auth.login", "static"}
     if request.endpoint in allowed or request.endpoint is None:
         return
-    if security.login_required_enabled() and not session.get("logged_in"):
-        return redirect(url_for("auth.login", next=request.path))
+    if not session.get("logged_in"):
+        if security.login_required_enabled():
+            return redirect(url_for("auth.login", next=request.path))
+        return
+    username = session.get("username")
+    sid = session.get("session_id")
+    if not session_tracker.touch_session(username, sid):
+        session.clear()
+        if security.login_required_enabled():
+            return redirect(url_for("auth.login", next=request.path))
 
 # ---- Logging Setup ----
 logging.basicConfig(

--- a/routes/admin_security.py
+++ b/routes/admin_security.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from flask import Blueprint, render_template, request, redirect, url_for, session
 from datetime import datetime
 
-from utils import security
+from utils import security, session_tracker
+import config
 
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
@@ -27,9 +28,12 @@ def security_page():
         return redirect(url_for("admin.security_page"))
     remaining = security.remaining_minutes()
     login_required = security.login_required_enabled()
+    active_count = len(session_tracker.active_sessions(config.ADMIN_USERNAME))
     return render_template(
         "admin/security.html",
         login_required=login_required,
         remaining=remaining,
         expires=security.load_settings().get("expires"),
+        active=active_count,
+        max_sessions=session_tracker.MAX_SESSIONS,
     )

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
-from utils import security
+from utils import security, session_tracker
+import uuid
 from dotenv import load_dotenv
 import config
 
@@ -22,8 +23,16 @@ def login():
         username = request.form.get("username", "")
         password = request.form.get("password", "")
         if username == ADMIN_USERNAME and password == ADMIN_PASSWORD:
+            token = str(uuid.uuid4())
+            if not session_tracker.register_session(username, token):
+                flash(
+                    "Maximum login limit reached (5 devices). Log out on another device to continue.",
+                    "danger",
+                )
+                return render_template("login.html"), 403
             session["logged_in"] = True
             session["username"] = username
+            session["session_id"] = token
             next_page = request.args.get("next") or url_for("artwork.home")
             return redirect(next_page)
         flash("Invalid username or password", "danger")
@@ -33,5 +42,9 @@ def login():
 @bp.route("/logout")
 def logout():
     """Clear session and redirect to login."""
+    token = session.get("session_id")
+    username = session.get("username")
+    if token and username:
+        session_tracker.remove_session(username, token)
     session.clear()
     return redirect(url_for("auth.login"))

--- a/templates/admin/security.html
+++ b/templates/admin/security.html
@@ -4,6 +4,7 @@
 <h1>Site Security</h1>
 <div class="security-panel">
   <p>Login required: <strong>{{ 'ON' if login_required else 'OFF' }}</strong></p>
+  <p>Active devices: {{ active }}/{{ max_sessions }}</p>
   {% if remaining %}
   <p>Login will re-enable in {{ remaining }} minute{{ 's' if remaining != 1 else '' }}.</p>
   {% endif %}

--- a/tests/test_session_limits.py
+++ b/tests/test_session_limits.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ["ADMIN_USERNAME"] = "robbie"
+os.environ["ADMIN_PASSWORD"] = "kangaroo123"
+
+
+def setup_app(tmp_path):
+    os.environ['LOGS_DIR'] = str(tmp_path / 'logs')
+    for mod in ('config', 'utils.session_tracker', 'routes.auth_routes', 'app'):
+        if mod in sys.modules:
+            importlib.reload(sys.modules[mod])
+    if 'app' not in sys.modules:
+        import app  # type: ignore
+    app_module = importlib.import_module('app')
+    return app_module.app
+
+
+def test_session_limit_enforced(tmp_path):
+    app = setup_app(tmp_path)
+    clients = []
+    for _ in range(5):
+        c = app.test_client()
+        resp = c.post('/login', data={'username': 'robbie', 'password': 'kangaroo123'}, follow_redirects=True)
+        assert resp.status_code == 200
+        clients.append(c)
+    extra = app.test_client()
+    resp = extra.post('/login', data={'username': 'robbie', 'password': 'kangaroo123'}, follow_redirects=False)
+    assert resp.status_code == 403
+    assert b'Maximum login limit' in resp.data
+
+    clients[0].get('/logout', follow_redirects=True)
+    resp = extra.post('/login', data={'username': 'robbie', 'password': 'kangaroo123'}, follow_redirects=True)
+    assert resp.status_code == 200

--- a/utils/session_tracker.py
+++ b/utils/session_tracker.py
@@ -1,0 +1,107 @@
+"""Utilities for tracking active user sessions with a device limit."""
+from __future__ import annotations
+
+import json
+import threading
+import datetime
+from pathlib import Path
+import contextlib
+import fcntl
+
+import config
+
+REGISTRY_FILE = config.LOGS_DIR / "session_registry.json"
+_LOCK = threading.Lock()
+MAX_SESSIONS = 5
+TIMEOUT_SECONDS = 7200  # 2 hours
+
+
+def _load_registry() -> dict:
+    if not REGISTRY_FILE.exists():
+        return {}
+    try:
+        with open(REGISTRY_FILE, "r", encoding="utf-8") as f:
+            with contextlib.suppress(OSError):
+                fcntl.flock(f, fcntl.LOCK_SH)
+            data = json.load(f)
+    except Exception:
+        REGISTRY_FILE.unlink(missing_ok=True)
+        return {}
+    return data
+
+
+def _save_registry(data: dict) -> None:
+    REGISTRY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REGISTRY_FILE.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    tmp.replace(REGISTRY_FILE)
+
+
+def _cleanup_expired(data: dict) -> dict:
+    now = datetime.datetime.utcnow()
+    changed = False
+    for user in list(data.keys()):
+        sessions = [
+            s
+            for s in data[user]
+            if now - datetime.datetime.fromisoformat(s["timestamp"]) < datetime.timedelta(seconds=TIMEOUT_SECONDS)
+        ]
+        if len(sessions) != len(data[user]):
+            changed = True
+        if sessions:
+            data[user] = sessions
+        else:
+            data.pop(user)
+            changed = True
+    if changed:
+        _save_registry(data)
+    return data
+
+
+def register_session(username: str, session_id: str) -> bool:
+    with _LOCK:
+        data = _load_registry()
+        data = _cleanup_expired(data)
+        sessions = data.get(username, [])
+        if len(sessions) >= MAX_SESSIONS:
+            return False
+        sessions.append({"session_id": session_id, "timestamp": datetime.datetime.utcnow().isoformat()})
+        data[username] = sessions
+        _save_registry(data)
+    return True
+
+
+def remove_session(username: str, session_id: str) -> None:
+    with _LOCK:
+        data = _load_registry()
+        data = _cleanup_expired(data)
+        if username in data:
+            data[username] = [s for s in data[username] if s.get("session_id") != session_id]
+            if not data[username]:
+                data.pop(username, None)
+        _save_registry(data)
+
+
+def touch_session(username: str, session_id: str) -> bool:
+    with _LOCK:
+        data = _load_registry()
+        data = _cleanup_expired(data)
+        for s in data.get(username, []):
+            if s.get("session_id") == session_id:
+                s["timestamp"] = datetime.datetime.utcnow().isoformat()
+                _save_registry(data)
+                return True
+    return False
+
+
+def active_sessions(username: str) -> list[dict]:
+    data = _load_registry()
+    data = _cleanup_expired(data)
+    return data.get(username, [])
+
+
+def all_sessions() -> dict:
+    data = _load_registry()
+    data = _cleanup_expired(data)
+    return data


### PR DESCRIPTION
## Summary
- add session tracking utilities
- limit concurrent sessions in `auth_routes`
- refresh session on each request in `app`
- show active device count on admin security page
- test session limits

## Testing
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687922b70ddc832eaf0bcaea5d8d125d