### PR TITLE
Setup overlay test template and routes

### DIFF
--- a/routes/test_routes.py
+++ b/routes/test_routes.py
@@ -1,7 +1,22 @@
 from flask import Blueprint, render_template
 
+# Blueprint for overlay migration testing
 test_bp = Blueprint('test_bp', __name__)
 
 @test_bp.route('/overlay-test')
 def overlay_test():
     return render_template('codex-library/Overlay-Menu-Design-Template/main-design-template.html')
+
+
+# Route to view edit listing overlay test template
+@test_bp.route('/test/edit-listing')
+def edit_listing_test():
+    """Render overlay version of edit listing template."""
+    return render_template('edit_listing_overlay_test.html')
+
+
+# Route to view artworks overlay test template
+@test_bp.route('/test/artworks')
+def artworks_test():
+    """Render overlay version of artworks template."""
+    return render_template('artworks_overlay_test.html')

--- a/static/css/main-overlay-test.css
+++ b/static/css/main-overlay-test.css
@@ -1,0 +1,531 @@
+/* THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. */
+        /* --- Global Styles & Variables --- */
+        :root {
+            --font-primary: monospace !important;
+            
+            /* Light Theme Colors */
+            --color-background: #FFFFFF;
+            --color-text: #111111;
+            --color-overlay-bg: rgba(248, 248, 248, 0.85);
+            --color-card-bg: #f9f9f9;
+            --color-header-border: #eeeeee;
+            --color-footer-bg: #FFFFFF;
+            --color-footer-text: #111111;
+            --color-footer-border: #dddddd;
+
+            /* Dark Theme Colors */
+            --dark-color-background: #111111;
+            --dark-color-text: #FFFFFF;
+            --dark-color-card-bg: #1a1a1a;
+            --dark-color-header-border: #2a2a2a;
+
+            /* Universal Colors */
+            --color-hover: #ffa52a;
+            --color-btn-bg: #111;
+            --color-btn-text: #fff;
+            --color-delete-hover: #8B0000;
+            --ease-quart: cubic-bezier(0.77, 0, 0.175, 1);
+        }
+
+        body.dark-theme {
+            --color-background: var(--dark-color-background);
+            --color-text: var(--dark-color-text);
+            /* --color-overlay-bg is intentionally not changed for dark theme */
+            --color-card-bg: var(--dark-color-card-bg);
+            --color-header-border: var(--dark-color-header-border);
+            --color-btn-bg: #222;
+        }
+
+        /* --- Base & Reset --- */
+        *, *::before, *::after {
+            box-sizing: border-box;
+        }
+
+        html, body {
+            height: 100%;
+        }
+
+        body {
+            margin: 0;
+            font-family: var(--font-primary);
+            background-color: var(--color-background);
+            color: var(--color-text);
+            font-size: 16px;
+            line-height: 1.6;
+            transition: background-color 0.3s, color 0.3s;
+            display: flex;
+            flex-direction: column;
+        }
+
+        a, button, input, h1, h2, h3, h4, p, div {
+             font-family: var(--font-primary);
+        }
+
+        a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        ul {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+
+        button {
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 0;
+            color: inherit; /* Ensure buttons inherit color */
+        }
+        
+        main {
+            flex-grow: 1;
+        }
+
+        /* --- Header --- */
+        .site-header, .overlay-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 1rem 1rem;
+            width: 100%;
+        }
+        
+        .site-header {
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            background-color: var(--color-background);
+            transition: background-color 0.3s, color 0.3s;
+            border-bottom: 1px solid var(--color-header-border);
+            color: var(--color-text); /* Ensure header text/icons match theme */
+        }
+
+        .header-left, .header-right {
+            flex: 1;
+        }
+        .header-center {
+            flex-grow: 0;
+        }
+        .header-right {
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        .site-logo {
+            font-weight: 400;
+            font-size: 1.3rem;
+            letter-spacing: 0.5px;
+        }
+
+        .logo-icon {
+        width: 35px;
+        height: 35px;
+        margin-right: 6px;
+        margin-bottom: none;
+        vertical-align: bottom;
+        }
+
+        .menu-toggle-btn, .menu-close-btn {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-size: 1rem;
+            font-weight: 500;
+        }
+
+        .menu-toggle-btn svg, .menu-close-btn svg {
+            width: 16px;
+            height: 16px;
+        }
+        
+        .theme-toggle-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 44px;
+            height: 44px;
+        }
+
+        .theme-toggle-btn svg {
+            width: 24px;
+            height: 24px;
+        }
+
+        .sun-icon { display: block; }
+        .moon-icon { display: none; }
+        body.dark-theme .sun-icon { display: none; }
+        body.dark-theme .moon-icon { display: block; }
+
+
+        /* --- Overlay Menu --- */
+        .overlay-menu {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100vh;
+            background-color: var(--color-overlay-bg);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            z-index: 999;
+            display: flex;
+            flex-direction: column;
+            padding: 0;
+            opacity: 0;
+            visibility: hidden;
+            transform: translateY(20px);
+            transition: opacity 0.5s var(--ease-quart), visibility 0.5s var(--ease-quart), transform 0.5s var(--ease-quart);
+            overflow-y: auto;
+            color: #111111; /* Force dark text inside the light overlay */
+        }
+
+        .overlay-menu.is-active {
+            opacity: 1;
+            visibility: visible;
+            transform: translateY(0);
+        }
+
+        .overlay-header {
+            flex-shrink: 0;
+            position: sticky;
+            top: 0;
+            background-color: var(--color-overlay-bg);
+        }
+
+        .overlay-nav {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            flex-grow: 1;
+            padding: 4rem 2rem;
+            gap: 2rem;
+            width: 100%;
+            max-width: 1200px;
+            margin: 0 auto 50px auto; /* Center horizontally */
+        }
+
+        .nav-column h3 {
+            font-size: 1rem;
+            font-weight: 700;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            opacity: 0.5;
+            margin: 0 0 1.5rem 0;
+        }
+
+        .nav-column ul {
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+
+        .nav-column a {
+            font-size: 1.2em;
+            font-weight: 500;
+            line-height: 1.3;
+            display: inline-block;
+            transition: color 0.3s var(--ease-quart);
+        }
+
+        .nav-column a:hover {
+            color: var(--color-hover);
+        }
+
+        /* --- Home Page Content --- */
+        .home-content-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 2rem;
+            padding: 2rem;
+            max-width: 1200px;
+            margin: 2rem auto 0 auto; /* Center horizontally */
+        }
+
+        .art-piece {
+            display: flex;
+            flex-direction: column;
+        }
+        .art-piece-info {
+            background-color: var(--color-card-bg);
+            padding: 1rem;
+            text-align: center;
+            transition: background-color 0.3s;
+        }
+        .art-piece img {
+            max-width: 100%;
+            height: auto;
+            display: block;
+            background-color: #eee;
+        }
+        .art-piece h2 {
+            font-size: 1.1rem;
+            margin: 0 0 0.5rem 0;
+        }
+        .art-piece p {
+            font-size: 0.9rem;
+            margin: 0;
+            opacity: 0.8;
+        }
+        
+        .art-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            margin-top: 1rem;
+        }
+
+        .btn-action {
+            width: 100%;
+            background-color: var(--color-btn-bg);
+            color: var(--color-btn-text);
+            padding: 0.75rem 1rem;
+            font-weight: 500;
+            text-align: center;
+            transition: background-color 0.3s;
+        }
+        
+        .btn-gemini {
+             background-color: var(--color-hover);
+             color: var(--color-btn-text);
+        }
+        
+        .btn-gemini:hover {
+            opacity: 0.8;
+        }
+
+        .btn-action.btn-analyse:hover {
+            background-color: var(--color-hover);
+        }
+
+        .btn-action.btn-delete:hover {
+            background-color: var(--color-delete-hover);
+        }
+
+        /* --- Footer --- */
+        .site-footer {
+            background-color: var(--color-footer-bg);
+            color: var(--color-footer-text);
+            height: 400px;
+            display: flex;
+            margin-top: 3rem;
+            flex-direction: column;
+            justify-content: center;
+            border-top: 1px solid var(--color-footer-border);
+        }
+
+        .footer-grid {
+            display: grid;
+            grid-template-columns: repeat(4, 1fr);
+            gap: 2rem;
+            max-width: 1200px;
+            width: 100%;
+            margin: 0 auto;
+            padding: 0 2rem;
+        }
+
+        .footer-column h4 {
+            font-size: 1rem;
+            margin: 20px 0 1rem 0;
+            text-transform: uppercase;
+            letter-spacing: 1px;
+            opacity: 0.7;
+        }
+
+        .footer-column ul {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+        }
+
+        .footer-column a {
+            opacity: 0.9;
+            transition: opacity 0.3s;
+        }
+        .footer-column a:hover {
+            opacity: 1;
+            color: var(--color-hover);
+        }
+
+        .copyright-bar {
+            padding: 1rem 2rem;
+            text-align: center;
+            font-size: 0.8rem;
+            margin-top: auto; /* Pushes to the bottom of the flex container */
+        }
+        
+        /* --- Gemini Modal --- */
+        .gemini-modal {
+            position: fixed;
+            z-index: 1001;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0,0,0,0.5);
+            display: none;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .gemini-modal-content {
+            background-color: var(--color-background);
+            color: var(--color-text);
+            margin: auto;
+            padding: 2rem;
+            border: 1px solid #888;
+            width: 80%;
+            max-width: 600px;
+            position: relative;
+        }
+        
+        .gemini-modal-close {
+            position: absolute;
+            top: 1rem;
+            right: 1.5rem;
+            font-size: 1.5rem;
+            font-weight: bold;
+            cursor: pointer;
+        }
+
+        .gemini-modal-body textarea {
+            width: 100%;
+            min-height: 200px;
+            margin-top: 1rem;
+            background-color: var(--color-card-bg);
+            color: var(--color-text);
+            border: 1px solid var(--color-header-border);
+            padding: 0.5rem;
+        }
+        
+        .gemini-modal-actions {
+            margin-top: 1rem;
+            display: flex;
+            gap: 1rem;
+        }
+
+        .loader {
+            border: 4px solid #f3f3f3;
+            border-radius: 50%;
+            border-top: 4px solid var(--color-hover);
+            width: 40px;
+            height: 40px;
+            animation: spin 2s linear infinite;
+            margin: 2rem auto;
+        }
+
+        @media (min-width: 1400px) {
+            .home-content-grid {
+                max-width: 1400px;
+            }
+        }
+
+        @media (min-width: 1600px) {
+            .home-content-grid {
+                max-width: 1600px;
+            }
+        }
+
+        @media (min-width: 1800px) {
+            .home-content-grid {
+                max-width: 1800px;
+            }
+        }
+
+        @media (min-width: 2400px) {
+            .home-content-grid {
+                max-width: 2400px;
+            }
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+
+
+        /* Responsive */
+        @media (max-width: 900px) {
+            .overlay-nav {
+                grid-template-columns: 1fr;
+                justify-items: center;
+                text-align: center;
+                gap: 3rem;
+            }
+            .nav-column a {
+                font-size: 1.5rem;
+            }
+            .footer-grid {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            .site-logo {
+            font-weight: 400;
+            font-size: 1rem;
+            letter-spacing: none;
+            }
+            .logo-icon {
+                width: 30px;
+                height: 30px;
+                margin-right: 4px;
+            }
+            .nav-column a {
+                font-size: .9em;
+                line-height: .2em;
+                display: inline-block;
+            }
+            .nav-column ul {
+                gap: .5rem;
+                margin-bottom: 30px;
+            }
+        }
+        
+        @media (max-width: 600px) {
+            .site-footer {
+                height: auto; /* Allow footer to grow on small screens */
+            }
+            .footer-grid {
+                grid-template-columns: 1fr;
+                text-align: center;
+                gap: 2rem;
+            }
+            .copyright-bar {
+                margin-top: 2rem;
+            }
+            .site-logo {
+                font-weight: 400;
+                font-size: 1rem;
+                letter-spacing: none;
+            }
+            .logo-icon {
+                width: 24px;
+                height: 24px;
+                margin-right: 2px;
+            }
+            .site-header {
+                height:50px
+            }
+            .menu-toggle-btn, .menu-close-btn {
+                font-size: 1em;
+            }
+        }
+
+        
+        @media (max-width: 400px) {
+            .site-header, .overlay-header {
+                flex-direction: column;
+                align-items: center;
+                padding: 1rem;
+            }
+            .header-left, .header-right {
+                width: 100%;
+                text-align: center;
+            }
+            .header-center {
+                margin-top: 1rem;
+            }
+            .menu-toggle-btn, .menu-close-btn {
+                font-size: .8em;
+            }
+        }

--- a/static/js/main-overlay-test.js
+++ b/static/js/main-overlay-test.js
@@ -1,0 +1,137 @@
+// THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration.
+        document.addEventListener('DOMContentLoaded', () => {
+            const menuToggle = document.getElementById('menu-toggle');
+            const menuClose = document.getElementById('menu-close');
+            const overlayMenu = document.getElementById('overlay-menu');
+            const themeToggle = document.getElementById('theme-toggle');
+            const body = document.body;
+
+            // --- Menu Logic ---
+            if (menuToggle && menuClose && overlayMenu) {
+                menuToggle.addEventListener('click', () => {
+                    overlayMenu.classList.add('is-active');
+                    body.style.overflow = 'hidden';
+                });
+
+                menuClose.addEventListener('click', () => {
+                    overlayMenu.classList.remove('is-active');
+                    body.style.overflow = '';
+                });
+            }
+
+            // --- Theme Logic ---
+            const applyTheme = (theme) => {
+                if (theme === 'dark') {
+                    body.classList.add('dark-theme');
+                } else {
+                    body.classList.remove('dark-theme');
+                }
+            };
+
+            const savedTheme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            
+            if (savedTheme) {
+                applyTheme(savedTheme);
+            } else {
+                applyTheme(prefersDark ? 'dark' : 'light');
+            }
+
+            if (themeToggle) {
+                themeToggle.addEventListener('click', () => {
+                    const currentTheme = body.classList.contains('dark-theme') ? 'dark' : 'light';
+                    const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                    applyTheme(newTheme);
+                    localStorage.setItem('theme', newTheme);
+                });
+            }
+            
+            // --- Gemini Modal Logic ---
+            const modal = document.getElementById('gemini-modal');
+            const modalTitle = document.getElementById('gemini-modal-title');
+            const modalBody = document.getElementById('gemini-modal-body');
+            const closeBtn = document.querySelector('.gemini-modal-close');
+            const copyBtn = document.getElementById('gemini-copy-btn');
+
+            const defaultPrompts = {
+                'generate-description': `Act as an expert art critic. Write an evocative and compelling gallery description for a piece of art titled "{ART_TITLE}". Focus on the potential materials, the mood it evokes, and the ideal setting for it. Make it about 150 words.`,
+                'create-social-post': `Generate a short, engaging Instagram post to promote a piece of art titled "{ART_TITLE}". Include a catchy opening line, a brief description, and 3-5 relevant hashtags.`
+            };
+
+            closeBtn.onclick = () => {
+                modal.style.display = "none";
+            }
+            window.onclick = (event) => {
+                if (event.target == modal) {
+                    modal.style.display = "none";
+                }
+            }
+
+            document.querySelectorAll('.btn-gemini').forEach(button => {
+                button.addEventListener('click', async (e) => {
+                    const action = e.target.dataset.action;
+                    const artPiece = e.target.closest('.art-piece');
+                    const artTitle = artPiece.querySelector('h2').textContent;
+                    
+                    let promptTemplate = '';
+                    let title = '';
+
+                    if (action === 'generate-description') {
+                        title = '✨ AI Art Description';
+                        promptTemplate = localStorage.getItem('geminiDescriptionPrompt') || defaultPrompts[action];
+                    } else if (action === 'create-social-post') {
+                        title = '✨ AI Social Media Post';
+                        promptTemplate = defaultPrompts[action]; // Using default for this one
+                    }
+
+                    const prompt = promptTemplate.replace('{ART_TITLE}', artTitle);
+
+                    modalTitle.textContent = title;
+                    modalBody.innerHTML = '<div class="loader"></div>';
+                    modal.style.display = 'flex';
+
+                    try {
+                        let chatHistory = [{ role: "user", parts: [{ text: prompt }] }];
+                        const payload = { contents: chatHistory };
+                        const apiKey = ""; 
+                        const apiUrl = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=" + apiKey;
+                        
+                        const response = await fetch(apiUrl, {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify(payload)
+                        });
+                        
+                        if (!response.ok) {
+                             throw new Error("API error: " + response.status + " " + response.statusText);
+                        }
+
+                        const result = await response.json();
+                        
+                        if (result.candidates && result.candidates.length > 0 &&
+                            result.candidates[0].content && result.candidates[0].content.parts &&
+                            result.candidates[0].content.parts.length > 0) {
+                            const text = result.candidates[0].content.parts[0].text;
+                            modalBody.innerHTML = '<textarea id="gemini-result">' + text + '</textarea>';
+                        } else {
+                            throw new Error("Invalid response structure from API.");
+                        }
+
+                    } catch (error) {
+                        console.error("Gemini API call failed:", error);
+                        modalBody.innerHTML = '<p>Sorry, something went wrong. Please try again. (' + error.message + ')</p>';
+                    }
+                });
+            });
+            
+            copyBtn.addEventListener('click', () => {
+                const resultTextarea = document.getElementById('gemini-result');
+                if (resultTextarea) {
+                    resultTextarea.select();
+                    document.execCommand('copy');
+                    copyBtn.textContent = 'Copied!';
+                    setTimeout(() => { copyBtn.textContent = 'Copy'; }, 2000);
+                }
+            });
+
+        });

--- a/templates/artworks_overlay_test.html
+++ b/templates/artworks_overlay_test.html
@@ -1,0 +1,78 @@
+<!-- THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. -->
+{# Use blueprint-prefixed endpoints like 'artwork.home' in url_for #}
+{% extends "main-overlay-test.html" %}
+{% block title %}Artwork | ArtNarrator{% endblock %}
+{% block content %}
+
+<div class="page-title-row">
+  <img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="hero-step-icon" alt="Step 2: Artwork" />
+  <h1>Artwork</h1>
+</div>
+
+<div class="gallery-section">
+
+  {% if ready_artworks %}
+    <h2 class="mb-3">Ready to Analyze</h2>
+    <div class="artwork-grid">
+      {% for art in ready_artworks %}
+      <div class="gallery-card">
+        <div class="card-thumb">
+          <img class="card-img-top"
+               src="{{ url_for('artwork.temp_image', filename=art.thumb) }}"
+               alt="{{ art.title }}">
+        </div>
+        <div class="card-details">
+          <div class="card-title">{{ art.title }}</div>
+          <form method="post" action="{{ url_for('artwork.analyze_upload', base=art.base) }}" class="analyze-form">
+            <button type="submit" class="btn btn-primary">Analyze</button>
+          </form>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if processed_artworks %}
+    <h2 class="mb-3 mt-5">Processed Artworks</h2>
+    <div class="artwork-grid">
+      {% for art in processed_artworks %}
+      <div class="gallery-card">
+        <div class="card-thumb">
+          <img class="card-img-top"
+               src="{{ url_for('artwork.processed_image', seo_folder=art.seo_folder, filename=art.thumb) }}"
+               alt="{{ art.title }}">
+        </div>
+        <div class="card-details">
+          <div class="card-title">{{ art.title }}</div>
+          <a href="{{ url_for('artwork.edit_listing', aspect=art.aspect, filename=art.filename) }}"class="btn btn-primary">Review</a>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  {% if finalised_artworks %}
+    <h2 class="mb-3 mt-5">Finalised Artworks</h2>
+    <div class="artwork-grid">
+      {% for art in finalised_artworks %}
+      <div class="gallery-card">
+        <div class="card-thumb">
+          <img class="card-img-top"
+               src="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=art.thumb) }}"
+               alt="{{ art.title }}">
+        </div>
+        <div class="card-details">
+          <div class="card-title">{{ art.title }}</div>
+          <a href="{{ url_for('artwork.edit_listing', aspect=art.aspect, filename=art.filename) }}" class="btn btn-secondary">Edit</a>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+  {% if not ready_artworks and not processed_artworks and not finalised_artworks %}
+    <p class="empty-msg">No artworks found. Please upload artwork to get started!</p>
+  {% endif %}
+
+</div>
+
+{% endblock %}

--- a/templates/edit_listing_overlay_test.html
+++ b/templates/edit_listing_overlay_test.html
@@ -1,0 +1,176 @@
+<!-- THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. -->
+{# Edit and finalise a single artwork listing with preview and metadata fields. #}
+{% extends "main-overlay-test.html" %}
+{% block title %}Edit Listing{% endblock %}
+{% block content %}
+
+<div class="review-artwork-grid row">
+  <!-- === Mockup Column === -->
+  <div class="col col-6 mockup-col">
+    <div class="main-thumb">
+      <a href="#" 
+    class="main-thumb-link" 
+    data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder+'.jpg') }}">
+    <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder+'-THUMB.jpg') }}" class="main-thumbnail-img" alt="thumbnail">
+  </a>
+<div class="thumb-note">Click thumbnail for full size</div>
+    </div>
+    <div>
+      <h3>Preview Mockups</h3>
+      <div class="mockup-preview-grid">
+        {% for m in mockups %}
+          <div class="mockup-card">
+            {% if m.exists %}
+              <a href="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}"
+                 class="mockup-img-link"
+                 data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}">
+                <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}" class="mockup-thumb-img" alt="mockup">
+              </a>
+            {% else %}
+              <div class="missing-img">Image Not Found</div>
+            {% endif %}
+            <form role="form" method="post" action="{{ url_for('artwork.review_swap_mockup', seo_folder=seo_folder, slot_idx=m.index) }}" class="swap-form">
+              <select name="new_category">
+                {% for c in categories %}
+                  <option value="{{ c }}" {% if c == m.category %}selected{% endif %}>{{ c }}</option>
+                {% endfor %}
+              </select>
+              <button type="submit" class="btn btn-sm">Swap</button>
+            </form>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <!-- === Edit Fields Column === -->
+  <div class="col col-6 edit-listing-col">
+    <div class="page-title-row" >
+      <img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="hero-step-icon" alt="Step 3: Edit Listing" />
+      <h1>Edit Listing</h1>
+    </div>
+    <!-- Status at Top -->
+    <p class="status-line {% if finalised %}status-finalised{% else %}status-pending{% endif %}">
+      Status: This artwork is {% if finalised %}<strong>finalised</strong>{% else %}<em>NOT yet finalised</em>{% endif %}
+      {% if locked %}<span class="locked-badge">Locked</span>{% endif %}
+    </p>
+    <!-- Validation errors -->
+    {% if errors %}
+      <div class="flash-error">
+        <ul>{% for e in errors %}<li>{{ e }}</li>{% endfor %}</ul>
+      </div>
+    {% endif %}
+
+    <!-- Main Edit Form -->
+    <form role="form" id="edit-form" method="POST" autocomplete="off">
+      <label>Title:</label>
+      <textarea name="title" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.title|e }}</textarea>
+
+      <label>Description:</label>
+      <textarea name="description" rows="12" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.description|e }}</textarea>
+
+      <label>Tags (comma-separated):</label>
+      <textarea name="tags" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.tags|e }}</textarea>
+
+      <label>Materials (comma-separated):</label>
+      <textarea name="materials" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.materials|e }}</textarea>
+
+      <div class="row-inline" style="display:flex; gap:1em;">
+        <div style="flex:1;">
+          <label>Primary Colour:</label>
+          <select name="primary_colour" class="long-field" {% if not editable %}disabled{% endif %}>
+            {% for col in colour_options %}
+              <option value="{{ col }}" {% if artwork.primary_colour==col %}selected{% endif %}>{{ col }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div style="flex:1;">
+          <label>Secondary Colour:</label>
+          <select name="secondary_colour" class="long-field" {% if not editable %}disabled{% endif %}>
+            {% for col in colour_options %}
+              <option value="{{ col }}" {% if artwork.secondary_colour==col %}selected{% endif %}>{{ col }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+
+      <label>SEO Filename:</label>
+      <input type="text" class="long-field" name="seo_filename" value="{{ artwork.seo_filename|e }}" {% if not editable %}disabled{% endif %}>
+
+      <div class="price-sku-row">
+        <div>
+          <label>Price:</label>
+          <input type="text" name="price" value="{{ artwork.price|e }}" class="long-field" {% if not editable %}disabled{% endif %}>
+        </div>
+        <div>
+          <label>SKU:</label>
+          <!-- SKU is assigned by the system and never user-editable -->
+          <input type="text" value="{{ artwork.sku|e }}" class="long-field" readonly disabled>
+        </div>
+      </div>
+
+      <label>Image URLs (one per line):</label>
+      <textarea name="images" rows="5" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.images|e }}</textarea>
+    </form>
+
+    <!-- Action Buttons -->
+    <div class="edit-actions-col">
+      <button form="edit-form" type="submit" name="action" value="save" class="btn btn-primary wide-btn" {% if not editable %}disabled{% endif %}>Save Changes</button>
+      <button form="edit-form" type="submit" name="action" value="delete" class="btn btn-danger wide-btn" onclick="return confirm('Delete this artwork and all files?');" {% if not editable %}disabled{% endif %}>Delete</button>
+      {% if not finalised %}
+        <form role='form' method="post" action="{{ url_for('artwork.finalise_artwork', aspect=aspect, filename=filename) }}" style="width:100%;">
+          <button type="submit" class="btn btn-primary wide-btn">Finalise</button>
+        </form>
+      {% endif %}
+      <form role='form' method="POST" action="{{ url_for('artwork.analyze_artwork', aspect=aspect, filename=filename) }}" style="width:100%;" class="analyze-form">
+        <button type="submit" class="btn btn-primary wide-btn" {% if locked %}disabled{% endif %}>Re-analyse Artwork</button>
+      </form>
+      {% if finalised and not locked %}
+        <form role='form' method="post" action="{{ url_for('artwork.lock_listing', aspect=aspect, filename=filename) }}" style="width:100%;">
+          <button type="submit" class="btn btn-primary wide-btn">Lock it in</button>
+        </form>
+      {% elif locked %}
+        <form role='form' method="post" action="{{ url_for('artwork.unlock_listing', aspect=aspect, filename=filename) }}" style="width:100%;">
+          <button type="submit" class="btn btn-primary wide-btn">Unlock</button>
+        </form>
+      {% endif %}
+      <form role='form' method="post" action="{{ url_for('artwork.reset_sku', aspect=aspect, filename=filename) }}" style="width:100%;">
+        <button type="submit" class="btn-primary wide-btn" {% if locked %}disabled{% endif %}>Reset SKU</button>
+      </form>
+    </div>
+    {% if openai_analysis %}
+      <div class="openai-details">
+        <h3>OpenAI Analysis Details</h3>
+        {% set entries = openai_analysis if openai_analysis is iterable and openai_analysis.__class__ != dict else [openai_analysis] %}
+        {% for info in entries %}
+        <table class="openai-table">
+          <tr><th>Original File</th><td>{{ info.original_file }}</td></tr>
+          <tr><th>Optimized File</th><td>{{ info.optimized_file }}</td></tr>
+          <tr><th>Size</th><td>{{ info.size_mb }} MB ({{ info.size_bytes }} bytes)</td></tr>
+          <tr><th>Dimensions</th><td>{{ info.dimensions }}</td></tr>
+          <tr><th>Time Sent</th><td>{{ info.time_sent }}</td></tr>
+          <tr><th>Time Responded</th><td>{{ info.time_responded }}</td></tr>
+          <tr><th>Duration</th><td>{{ info.duration_sec }} s</td></tr>
+          <tr><th>Status</th><td>{{ info.status }}</td></tr>
+          {% if info.api_response %}<tr><th>API Response</th><td>{{ info.api_response }}</td></tr>{% endif %}
+          {% if info.naming_method %}<tr><th>Naming Method</th><td>{{ info.naming_method }}{% if info.used_fallback_naming %} (fallback){% endif %}</td></tr>{% endif %}
+        </table>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </div>
+</div>
+
+<!-- Mockup carousel modal -->
+<div id="mockup-carousel" class="modal-bg" tabindex="-1">
+  <button id="carousel-close" class="modal-close" aria-label="Close">&times;</button>
+  <button id="carousel-prev" class="carousel-nav" aria-label="Previous">&#10094;</button>
+  <div class="modal-img">
+    <img id="carousel-img" src="" alt="Mockup Preview" />
+  </div>
+  <button id="carousel-next" class="carousel-nav" aria-label="Next">&#10095;</button>
+</div>
+
+
+<script src="{{ url_for('static', filename='js/edit_listing.js') }}"></script>
+{% endblock %}

--- a/templates/main-overlay-test.html
+++ b/templates/main-overlay-test.html
@@ -1,0 +1,272 @@
+<!-- THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ART Narrator</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main-overlay-test.css') }}">
+    <script src="{{ url_for('static', filename='js/main-overlay-test.js') }}"></script>
+</head>
+<body>
+
+    <!-- Site Header -->
+    <header class="site-header">
+        <div class="header-left">
+             <a href="{{ url_for('artwork.home') }}" class="site-logo">
+            <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" alt="" class="logo-icon">ArtNarrator</a>
+        </div>
+        <div class="header-center">
+            <button id="menu-toggle" class="menu-toggle-btn" aria-label="Open menu">
+                Menu
+                <!-- Arrow Down Icon -->
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" /></svg>
+            </button>
+        </div>
+        <div class="header-right">
+            <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+                <!-- Sun Icon -->
+                <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.106a.75.75 0 011.06-1.06l1.591 1.59a.75.75 0 01-1.06 1.06l-1.59-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.894 17.894a.75.75 0 01-1.06 1.06l-1.59-1.591a.75.75 0 111.06-1.06l1.59 1.59zM12 18.75a.75.75 0 01-.75.75v2.25a.75.75 0 011.5 0V19.5a.75.75 0 01-.75-.75zM6.106 18.894a.75.75 0 01-1.06-1.06l1.59-1.59a.75.75 0 011.06 1.06l-1.59 1.59zM3.75 12a.75.75 0 01.75-.75h2.25a.75.75 0 010 1.5H4.5a.75.75 0 01-.75-.75zM6.106 5.046a.75.75 0 011.06 1.06l-1.59 1.591a.75.75 0 01-1.06-1.06l1.59-1.59z"></path></svg>
+                <!-- Moon Icon -->
+                <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69a.75.75 0 01.981.981A10.503 10.503 0 0118 18a10.5 10.5 0 01-10.5-10.5c0-1.25.22-2.454.622-3.574a.75.75 0 01.806-.162z" clip-rule="evenodd"></path></svg>
+            </button>
+        </div>
+    </header>
+
+    <!-- Overlay Menu -->
+    <div id="overlay-menu" class="overlay-menu">
+    <div class="overlay-header">
+        <div class="header-left">
+             <a href="{{ url_for('artwork.home') }}" class="site-logo">
+            <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" alt="" class="logo-icon">ArtNarrator</a>
+        </div>
+        <div class="header-center">
+            <button id="menu-close" class="menu-close-btn" aria-label="Close menu">
+                Close
+                <!-- Arrow Up Icon -->
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M14.78 11.78a.75.75 0 0 1-1.06 0L10 8.06l-3.72 3.72a.75.75 0 1 1-1.06-1.06l4.25-4.25a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06Z" clip-rule="evenodd" /></svg>
+            </button>
+        </div>
+        <div class="header-right">
+            <!-- This empty div balances the flexbox layout -->
+        </div>
+    </div>
+    <nav class="overlay-nav">
+        <div class="nav-column">
+            <h3>Artwork & Gallery</h3>
+            <ul>
+                <li><a href="/upload.html">Upload Artwork</a></li>
+                <li><a href="/artworks.html">All Artworks</a></li>
+                <li><a href="/gallery.html">Gallery</a></li>
+                <li><a href="/finalised.html">Finalised</a></li>
+                <li><a href="/locked.html">Locked</a></li>
+                <li><a href="/edit_listing.html">Edit Listing</a></li>
+            </ul>
+        </div>
+        <div class="nav-column">
+            <h3>Workflow & Tools</h3>
+            <ul>
+                <li><a href="/composites_preview.html">Composites Preview</a></li>
+                <li><a href="/review.html">Review Listing</a></li>
+                <li><a href="/mockup_selector.html">Mockup Selector</a></li>
+                <li><a href="/test_description.html">Test Description</a></li>
+                <li><a href="/upload_results.html">Upload Results</a></li>
+                <li><a href="/main.html">Main (Home)</a></li>
+            </ul>
+        </div>
+        <div class="nav-column">
+            <h3>Exports & Admin</h3>
+            <ul>
+                <li><a href="/sellbrite_exports.html">Sellbrite Exports</a></li>
+                <li><a href="/sellbrite_csv_preview.html">Sellbrite CSV Preview</a></li>
+                <li><a href="/sellbrite_log.html">Sellbrite Log</a></li>
+                <li><a href="/admin/dashboard.html">Admin Dashboard</a></li>
+                <li><a href="/admin/security.html">Admin Security</a></li>
+                <li><a href="/admin/users.html">Admin Users</a></li>
+                <li><a href="/login.html">Login</a></li>
+            </ul>
+        </div>
+    </nav>
+</div>
+
+    <!-- Main Content -->
+    <main>
+        <div class="home-content-grid">
+            <!-- Placeholder art pieces -->
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>M_001 Travertine Chair</h2>
+                    <p>by Monolith</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>Chunk Chair</h2>
+                    <p>by Obscure Objects</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>M_001 Travertine Chair</h2>
+                    <p>by Monolith</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>Chunk Chair</h2>
+                    <p>by Obscure Objects</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>M_001 Travertine Chair</h2>
+                    <p>by Monolith</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>Chunk Chair</h2>
+                    <p>by Obscure Objects</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+            <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>M_001 Travertine Chair</h2>
+                    <p>by Monolith</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+             <div class="art-piece">
+                <div class="art-piece-info">
+                    <img src="https://placehold.co/600x800/f0f0f0/ccc?text=Artwork" alt="Placeholder for an art piece" onerror="this.onerror=null;this.src='https://placehold.co/600x800/f0f0f0/ccc?text=Image+Not+Found';">
+                    <h2>Mirror Lounge Chair</h2>
+                    <p>by Project 213A</p>
+                </div>
+                <div class="art-actions">
+                    <button class="btn-action btn-analyse">Analyse</button>
+                    <button class="btn-action btn-delete">Delete</button>
+
+                    <button class="btn-action btn-gemini" data-action="create-social-post">✨ Create Social Post</button>
+                </div>
+            </div>
+        </div>
+    </main>
+    
+    <!-- Gemini Modal -->
+    <div id="gemini-modal" class="gemini-modal">
+        <div class="gemini-modal-content">
+            <span class="gemini-modal-close">&times;</span>
+            <h3 id="gemini-modal-title">AI Generation</h3>
+            <div id="gemini-modal-body" class="gemini-modal-body">
+                <!-- Content will be injected here -->
+            </div>
+             <div class="gemini-modal-actions">
+                <button id="gemini-copy-btn" class="btn-action">Copy</button>
+            </div>
+        </div>
+    </div>
+
+
+    <!-- Footer -->
+    <footer class="site-footer">
+    <div class="footer-grid">
+        <div class="footer-column">
+            <h4>Navigate</h4>
+            <ul>
+                <li><a href="/index.html">Home</a></li>
+                <li><a href="/about.html">About</a></li>
+                <li><a href="/contact.html">Contact</a></li>
+                <li><a href="/login.html">Login</a></li>
+            </ul>
+        </div>
+        <div class="footer-column">
+            <h4>Artwork & Gallery</h4>
+            <ul>
+                <li><a href="/upload.html">Upload Artwork</a></li>
+                <li><a href="/artworks.html">Artworks</a></li>
+                <li><a href="/edit_listing.html">Edit Listing</a></li>
+                <li><a href="/finalised.html">Finalised</a></li>
+                <li><a href="/gallery.html">Gallery</a></li>
+                <li><a href="/locked.html">Locked</a></li>
+            </ul>
+        </div>
+        <div class="footer-column">
+            <h4>Workflow & Tools</h4>
+            <ul>
+                <li><a href="/composites_preview.html">Composites Preview</a></li>
+                <li><a href="/review.html">Review</a></li>
+                <li><a href="/mockup_selector.html">Mockups</a></li>
+                <li><a href="/test_description.html">Test Description</a></li>
+                <li><a href="/upload_results.html">Upload Results</a></li>
+            </ul>
+        </div>
+        <div class="footer-column">
+            <h4>Exports & Admin</h4>
+            <ul>
+                <li><a href="/sellbrite_exports.html">Sellbrite Exports</a></li>
+                <li><a href="/sellbrite_csv_preview.html">Sellbrite CSV Preview</a></li>
+                <li><a href="/sellbrite_log.html">Sellbrite Log</a></li>
+                <li><a href="/admin/dashboard.html">Admin Dashboard</a></li>
+                <li><a href="/admin/security.html">Admin Security</a></li>
+                <li><a href="/admin/users.html">Admin Users</a></li>
+            </ul>
+        </div>
+    </div>
+    <div class="copyright-bar">
+        © Copyright 2025 ART Narrator All rights reserved | <a href="https://artnarrator.com">artnarrator.com</a> designed and built by Robin Custance.
+    </div>
+</footer>
+
+
+    <!-- JavaScript -->
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate main overlay template for testing and link external CSS/JS
- extract overlay CSS and JS into static files
- add overlay versions of `edit_listing.html` and `artworks.html`
- add routes to preview these overlay templates

## Testing
- `pytest -q tests/`

------
https://chatgpt.com/codex/tasks/task_e_6879cccbc0c4832e9a05f6edd039af6d