### PR TITLE
Migrate templates to overlay layout

### DIFF
--- a/static/css/404.css
+++ b/static/css/404.css
@@ -1,0 +1,28 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f8f8f8;
+    color: #333;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+h1 {
+    font-size: 3em;
+    color: #FF6347;
+}
+p {
+    font-size: 1.2em;
+    color: #555;
+}
+a {
+    font-size: 1.1em;
+    color: #4682B4;
+    text-decoration: none;
+    margin-top: 20px;
+}
+a:hover {
+    text-decoration: underline;
+}

--- a/static/js/analysis-modal.js
+++ b/static/js/analysis-modal.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const modal = document.getElementById('analysis-modal');
+  const bar = document.getElementById('analysis-bar');
+  const statusEl = document.getElementById('analysis-status');
+  const closeBtn = document.getElementById('analysis-close');
+  const statusUrl = document.body.dataset.analysisStatusUrl;
+  let pollStatus;
+
+  function openModal() {
+    modal.classList.add('active');
+    fetchStatus();
+    pollStatus = setInterval(fetchStatus, 1000);
+    modal.querySelector('.analysis-box').focus();
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    clearInterval(pollStatus);
+  }
+
+  function fetchStatus() {
+    fetch(statusUrl)
+      .then(r => r.json())
+      .then(d => {
+        const pct = d.percent || 0;
+        bar.style.width = pct + '%';
+        bar.setAttribute('aria-valuenow', pct);
+        statusEl.textContent = d.step || '';
+      });
+  }
+
+  if (closeBtn) closeBtn.addEventListener('click', closeModal);
+  modal.addEventListener('keydown', function(e) {
+    if (e.key === 'Escape') { e.preventDefault(); closeModal(); }
+  });
+
+  document.querySelectorAll('form.analyze-form').forEach(f => {
+    f.addEventListener('submit', function(ev) {
+      ev.preventDefault();
+      openModal();
+      const data = new FormData(f);
+      fetch(f.action, {method: 'POST', body: data})
+        .then(resp => resp.text().then(() => resp.url))
+        .then(url => { setTimeout(() => { closeModal(); window.location.href = url; }, 1000); });
+    });
+  });
+});

--- a/static/js/gallery.js
+++ b/static/js/gallery.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modalBg = document.getElementById('final-modal-bg');
+  const modalImg = document.getElementById('final-modal-img');
+  const closeBtn = document.getElementById('final-modal-close');
+  const grid = document.querySelector('.finalised-grid');
+  const viewKey = grid ? grid.dataset.viewKey || 'view' : 'view';
+  document.querySelectorAll('.final-img-link').forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      if (modalBg && modalImg) {
+        modalImg.src = link.dataset.img;
+        modalBg.style.display = 'flex';
+      }
+    });
+  });
+  if (closeBtn) closeBtn.onclick = () => {
+    modalBg.style.display = 'none';
+    modalImg.src = '';
+  };
+  if (modalBg) modalBg.onclick = e => {
+    if (e.target === modalBg) {
+      modalBg.style.display = 'none';
+      modalImg.src = '';
+    }
+  };
+  document.querySelectorAll('.locked-delete-form').forEach(f => {
+    f.addEventListener('submit', ev => {
+      const val = prompt('This listing is locked and will be permanently deleted. Type DELETE to confirm');
+      if (val !== 'DELETE') { ev.preventDefault(); }
+      else { f.querySelector('input[name="confirm"]').value = 'DELETE'; }
+    });
+  });
+  const gBtn = document.getElementById('grid-view-btn');
+  const lBtn = document.getElementById('list-view-btn');
+  function apply(v) {
+    if (!grid) return;
+    if (v === 'list') { grid.classList.add('list-view'); }
+    else { grid.classList.remove('list-view'); }
+  }
+  if (gBtn) gBtn.addEventListener('click', () => { apply('grid'); localStorage.setItem(viewKey, 'grid'); });
+  if (lBtn) lBtn.addEventListener('click', () => { apply('list'); localStorage.setItem(viewKey, 'list'); });
+  apply(localStorage.getItem(viewKey) || 'grid');
+});

--- a/templates/404.html
+++ b/templates/404.html
@@ -4,36 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oops! Page Not Found</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            background-color: #f8f8f8;
-            color: #333;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            margin: 0;
-        }
-        h1 {
-            font-size: 3em;
-            color: #FF6347;
-        }
-        p {
-            font-size: 1.2em;
-            color: #555;
-        }
-        a {
-            font-size: 1.1em;
-            color: #4682B4;
-            text-decoration: none;
-            margin-top: 20px;
-        }
-        a:hover {
-            text-decoration: underline;
-        }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/404.css') }}">
 </head>
 <body>
     <h1>Oops! Something went wrong...</h1>

--- a/templates/artworks_overlay_test.html
+++ b/templates/artworks_overlay_test.html
@@ -1,6 +1,5 @@
-<!-- THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. -->
 {# Use blueprint-prefixed endpoints like 'artwork.home' in url_for #}
-{% extends "main-overlay-test.html" %}
+{% extends "main.html" %}
 {% block title %}Artwork | ArtNarrator{% endblock %}
 {% block content %}
 

--- a/templates/edit_listing_overlay_test.html
+++ b/templates/edit_listing_overlay_test.html
@@ -1,6 +1,5 @@
-<!-- THIS IS A TEST MIGRATION TEMPLATE. Safe to delete after production migration. -->
 {# Edit and finalise a single artwork listing with preview and metadata fields. #}
-{% extends "main-overlay-test.html" %}
+{% extends "main.html" %}
 {% block title %}Edit Listing{% endblock %}
 {% block content %}
 

--- a/templates/finalised.html
+++ b/templates/finalised.html
@@ -17,7 +17,7 @@
 {% if not artworks %}
   <p>No artworks have been finalised yet. Come back after you approve some beautiful pieces!</p>
 {% else %}
-<div class="finalised-grid">
+<div class="finalised-grid" data-view-key="view">
   {% for art in artworks %}
   <div class="final-card">
     <div class="card-thumb">
@@ -88,41 +88,5 @@
   <button id="final-modal-close" class="modal-close" aria-label="Close modal">&times;</button>
   <div class="modal-img"><img id="final-modal-img" src="" alt="Full image"/></div>
 </div>
-<script>
-  document.querySelectorAll('.final-img-link').forEach(link => {
-    link.addEventListener('click', function(e){
-      e.preventDefault();
-      const modal = document.getElementById('final-modal-bg');
-      const img = document.getElementById('final-modal-img');
-      img.src = this.dataset.img;
-      modal.style.display = 'flex';
-    });
-  });
-  document.getElementById('final-modal-close').onclick = function(){
-    document.getElementById('final-modal-bg').style.display='none';
-    document.getElementById('final-modal-img').src='';
-  };
-  document.getElementById('final-modal-bg').onclick = function(e){
-    if(e.target===this){
-      this.style.display='none';
-      document.getElementById('final-modal-img').src='';
-    }
-  };
-  document.querySelectorAll('.locked-delete-form').forEach(f=>{
-    f.addEventListener('submit',function(ev){
-      const val=prompt('This listing is locked and will be permanently deleted. Type DELETE to confirm');
-      if(val!=='DELETE'){ev.preventDefault();}
-      else{this.querySelector('input[name="confirm"]').value='DELETE';}
-    });
-  });
-  const gBtn=document.getElementById('grid-view-btn');
-  const lBtn=document.getElementById('list-view-btn');
-  const grid=document.querySelector('.finalised-grid');
-  function apply(v){
-    if(v==='list'){grid.classList.add('list-view');} else {grid.classList.remove('list-view');}
-  }
-  if(gBtn) gBtn.addEventListener('click',()=>{apply('grid'); localStorage.setItem('view','grid');});
-  if(lBtn) lBtn.addEventListener('click',()=>{apply('list'); localStorage.setItem('view','list');});
-  apply(localStorage.getItem('view')||'grid');
-</script>
+<script src="{{ url_for('static', filename='js/gallery.js') }}"></script>
 {% endblock %}

--- a/templates/locked.html
+++ b/templates/locked.html
@@ -14,7 +14,7 @@
 {% if not artworks %}
   <p>No artworks have been finalised yet. Come back after you approve some beautiful pieces!</p>
 {% else %}
-<div class="finalised-grid">
+<div class="finalised-grid" data-view-key="lockedView">
   {% for art in artworks %}
   <div class="final-card">
     <div class="card-thumb">
@@ -75,39 +75,5 @@
   <button id="final-modal-close" class="modal-close" aria-label="Close modal">&times;</button>
   <div class="modal-img"><img id="final-modal-img" src="" alt="Full image"/></div>
 </div>
-<script>
-  document.querySelectorAll('.final-img-link').forEach(link => {
-    link.addEventListener('click', function(e){
-      e.preventDefault();
-      const modal = document.getElementById('final-modal-bg');
-      const img = document.getElementById('final-modal-img');
-      img.src = this.dataset.img;
-      modal.style.display = 'flex';
-    });
-  });
-  document.getElementById('final-modal-close').onclick = function(){
-    document.getElementById('final-modal-bg').style.display='none';
-    document.getElementById('final-modal-img').src='';
-  };
-  document.getElementById('final-modal-bg').onclick = function(e){
-    if(e.target===this){
-      this.style.display='none';
-      document.getElementById('final-modal-img').src='';
-    }
-  };
-  document.querySelectorAll('.locked-delete-form').forEach(f=>{
-    f.addEventListener('submit',function(ev){
-      const val=prompt('This listing is locked and will be permanently deleted. Type DELETE to confirm');
-      if(val!=='DELETE'){ev.preventDefault();}
-      else{this.querySelector('input[name="confirm"]').value='DELETE';}
-    });
-  });
-  const gBtn=document.getElementById('grid-view-btn');
-  const lBtn=document.getElementById('list-view-btn');
-  const grid=document.querySelector('.finalised-grid');
-  function apply(v){ if(v==='list'){grid.classList.add('list-view');} else {grid.classList.remove('list-view');} }
-  if(gBtn) gBtn.addEventListener('click',()=>{apply('grid'); localStorage.setItem('lockedView','grid');});
-  if(lBtn) lBtn.addEventListener('click',()=>{apply('list'); localStorage.setItem('lockedView','list');});
-  apply(localStorage.getItem('lockedView')||'grid');
-</script>
+<script src="{{ url_for('static', filename='js/gallery.js') }}"></script>
 {% endblock %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -1,101 +1,166 @@
-{# All url_for calls use blueprint prefixes like 'artwork.upload_artwork' #}
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <script>
-    const savedTheme = localStorage.getItem('theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const theme = savedTheme || (prefersDark ? 'dark' : 'light');
-    document.documentElement.classList.add('theme-' + theme);
-  </script>
-  <title>{% block title %}ArtNarrator{% endblock %}</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <script>
+        const savedTheme = localStorage.getItem('theme');
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = savedTheme || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.add('theme-' + theme);
+    </script>
+    <title>{% block title %}ArtNarrator{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main-overlay-test.css') }}">
 </head>
-<body>
-  <!-- ========== [MA.1] Top Navigation ========== -->
-  {% include "partials/topnav.html" %}
-  <main class="container">
-    <!-- ========== [MA.2] Flash Message Area ========== -->
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="flash">
-          {% for m in messages %}
-            {{ m }}
-          {% endfor %}
+<body data-analysis-status-url="{{ url_for('artwork.analysis_status') }}">
+    <!-- Site Header -->
+    <header class="site-header">
+        <div class="header-left">
+            <a href="{{ url_for('artwork.home') }}" class="site-logo">
+                <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" alt="" class="logo-icon">ArtNarrator
+            </a>
         </div>
-      {% endif %}
-    {% endwith %}
-    <!-- ========== [MA.3] Main Content Block ========== -->
-    {% block content %}{% endblock %}
-  </main>
+        <div class="header-center">
+            <button id="menu-toggle" class="menu-toggle-btn" aria-label="Open menu">
+                Menu
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd"/></svg>
+            </button>
+        </div>
+        <div class="header-right">
+            <button id="theme-toggle" class="theme-toggle-btn" aria-label="Toggle theme">
+                <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2.25a.75.75 0 01.75.75v2.25a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM7.5 12a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM18.894 6.106a.75.75 0 011.06-1.06l1.591 1.59a.75.75 0 01-1.06 1.06l-1.59-1.59zM21.75 12a.75.75 0 01-.75.75h-2.25a.75.75 0 010-1.5H21a.75.75 0 01.75.75zM17.894 17.894a.75.75 0 01-1.06 1.06l-1.59-1.591a.75.75 0 111.06-1.06l1.59 1.59zM12 18.75a.75.75 0 01-.75.75v2.25a.75.75 0 011.5 0V19.5a.75.75 0 01-.75-.75zM6.106 18.894a.75.75 0 01-1.06-1.06l1.59-1.59a.75.75 0 011.06 1.06l-1.59 1.59zM3.75 12a.75.75 0 01.75-.75h2.25a.75.75 0 010 1.5H4.5a.75.75 0 01-.75-.75zM6.106 5.046a.75.75 0 011.06 1.06l-1.59 1.591a.75.75 0 01-1.06-1.06l1.59-1.59z"/></svg>
+                <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path fill-rule="evenodd" d="M9.528 1.718a.75.75 0 01.162.819A8.97 8.97 0 009 6a9 9 0 009 9 8.97 8.97 0 003.463-.69a.75.75 0 001.981.981A10.503 10.503 0 0118 18a10.5 10.5 0 01-10.5-10.5c0-1.25.22-2.454.622-3.574a.75.75 0 01.806-.162z" clip-rule="evenodd"/></svg>
+            </button>
+        </div>
+    </header>
 
-  <!-- Analysis Progress Modal -->
-  <div id="analysis-modal" class="analysis-modal" role="dialog" aria-modal="true">
-    <div class="analysis-box" tabindex="-1">
-      <button id="analysis-close" class="modal-close" aria-label="Close">&times;</button>
-      <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" class="progress-icon" alt="">
-      <h3>Analyzing Artwork...</h3>
-      <div class="analysis-progress" aria-label="analysis progress">
-        <div id="analysis-bar" class="analysis-progress-bar"
-             role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
-      </div>
-      <div id="analysis-status" class="analysis-status" aria-live="polite"></div>
-      <div class="analysis-friendly">This can take up to a couple of minutes. Go have a coffee while the AI works its magic! ☕️</div>
+    <!-- Overlay Menu -->
+    <div id="overlay-menu" class="overlay-menu">
+        <div class="overlay-header">
+            <div class="header-left">
+                <a href="{{ url_for('artwork.home') }}" class="site-logo">
+                    <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" alt="" class="logo-icon">ArtNarrator
+                </a>
+            </div>
+            <div class="header-center">
+                <button id="menu-close" class="menu-close-btn" aria-label="Close menu">
+                    Close
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M14.78 11.78a.75.75 0 0 1-1.06 0L10 8.06l-3.72 3.72a.75.75 0 1 1-1.06-1.06l4.25-4.25a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06Z" clip-rule="evenodd"/></svg>
+                </button>
+            </div>
+            <div class="header-right"></div>
+        </div>
+        <nav class="overlay-nav">
+            <div class="nav-column">
+                <h3>Artwork &amp; Gallery</h3>
+                <ul>
+                    <li><a href="{{ url_for('artwork.upload_artwork') }}">Upload Artwork</a></li>
+                    <li><a href="{{ url_for('artwork.artworks') }}">All Artworks</a></li>
+                    <li><a href="{{ url_for('artwork.finalised_gallery') }}">Finalised</a></li>
+                    <li><a href="{{ url_for('artwork.locked_gallery') }}">Locked</a></li>
+                </ul>
+            </div>
+            <div class="nav-column">
+                <h3>Workflow &amp; Tools</h3>
+                <ul>
+                    <li><a href="{{ url_for('artwork.select') }}">Composites Preview</a></li>
+                    <li><a href="{{ url_for('artwork.select') }}">Mockup Selector</a></li>
+                </ul>
+            </div>
+            <div class="nav-column">
+                <h3>Exports &amp; Admin</h3>
+                <ul>
+                    <li><a href="{{ url_for('exports.sellbrite_exports') }}">Sellbrite Exports</a></li>
+                    <li><a href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
+                    <li><a href="{{ url_for('admin.security_page') }}">Admin Security</a></li>
+                    <li><a href="{{ url_for('admin.users_page') }}">Admin Users</a></li>
+                    <li><a href="{{ url_for('auth.login') }}">Login</a></li>
+                </ul>
+            </div>
+        </nav>
     </div>
-  </div>
 
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      const modal = document.getElementById('analysis-modal');
-      const bar = document.getElementById('analysis-bar');
-      const statusEl = document.getElementById('analysis-status');
-      const closeBtn = document.getElementById('analysis-close');
-      const statusUrl = "{{ url_for('artwork.analysis_status') }}";
-      let pollStatus;
+    <!-- Main Content -->
+    <main>
+        {% with messages = get_flashed_messages() %}
+            {% if messages %}
+                <div class="flash">
+                    {% for m in messages %}{{ m }}{% endfor %}
+                </div>
+            {% endif %}
+        {% endwith %}
+        {% block content %}{% endblock %}
+    </main>
 
-      function openModal() {
-        modal.classList.add('active');
-        fetchStatus();
-        pollStatus = setInterval(fetchStatus, 1000);
-        modal.querySelector('.analysis-box').focus();
-      }
+    <!-- Gemini Modal -->
+    <div id="gemini-modal" class="gemini-modal">
+        <div class="gemini-modal-content">
+            <span class="gemini-modal-close">&times;</span>
+            <h3 id="gemini-modal-title">AI Generation</h3>
+            <div id="gemini-modal-body" class="gemini-modal-body"></div>
+            <div class="gemini-modal-actions">
+                <button id="gemini-copy-btn" class="btn-action">Copy</button>
+            </div>
+        </div>
+    </div>
 
-      function closeModal() {
-        modal.classList.remove('active');
-        clearInterval(pollStatus);
-      }
+    <!-- Analysis Progress Modal -->
+    <div id="analysis-modal" class="analysis-modal" role="dialog" aria-modal="true">
+        <div class="analysis-box" tabindex="-1">
+            <button id="analysis-close" class="modal-close" aria-label="Close">&times;</button>
+            <img src="{{ url_for('static', filename='icons/svg/light/palette-light.svg') }}" class="progress-icon" alt="">
+            <h3>Analyzing Artwork...</h3>
+            <div class="analysis-progress" aria-label="analysis progress">
+                <div id="analysis-bar" class="analysis-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"></div>
+            </div>
+            <div id="analysis-status" class="analysis-status" aria-live="polite"></div>
+            <div class="analysis-friendly">This can take up to a couple of minutes. Go have a coffee while the AI works its magic! ☕️</div>
+        </div>
+    </div>
 
-      function fetchStatus() {
-        fetch(statusUrl)
-          .then(r => r.json())
-          .then(d => {
-            const pct = d.percent || 0;
-            bar.style.width = pct + '%';
-            bar.setAttribute('aria-valuenow', pct);
-            statusEl.textContent = d.step || '';
-          });
-      }
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-grid">
+            <div class="footer-column">
+                <h4>Navigate</h4>
+                <ul>
+                    <li><a href="{{ url_for('artwork.home') }}">Home</a></li>
+                    <li><a href="{{ url_for('auth.login') }}">Login</a></li>
+                </ul>
+            </div>
+            <div class="footer-column">
+                <h4>Artwork &amp; Gallery</h4>
+                <ul>
+                    <li><a href="{{ url_for('artwork.upload_artwork') }}">Upload Artwork</a></li>
+                    <li><a href="{{ url_for('artwork.artworks') }}">Artworks</a></li>
+                    <li><a href="{{ url_for('artwork.finalised_gallery') }}">Finalised</a></li>
+                    <li><a href="{{ url_for('artwork.locked_gallery') }}">Locked</a></li>
+                </ul>
+            </div>
+            <div class="footer-column">
+                <h4>Workflow &amp; Tools</h4>
+                <ul>
+                    <li><a href="{{ url_for('artwork.select') }}">Composites Preview</a></li>
+                    <li><a href="{{ url_for('artwork.select') }}">Mockups</a></li>
+                </ul>
+            </div>
+            <div class="footer-column">
+                <h4>Exports &amp; Admin</h4>
+                <ul>
+                    <li><a href="{{ url_for('exports.sellbrite_exports') }}">Sellbrite Exports</a></li>
+                    <li><a href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
+                    <li><a href="{{ url_for('admin.security_page') }}">Admin Security</a></li>
+                    <li><a href="{{ url_for('admin.users_page') }}">Admin Users</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="copyright-bar">
+            © Copyright 2025 ART Narrator All rights reserved | <a href="https://artnarrator.com">artnarrator.com</a> designed and built by Robin Custance.
+        </div>
+    </footer>
 
-      if (closeBtn) closeBtn.addEventListener('click', closeModal);
-      modal.addEventListener('keydown', function(e) {
-        if (e.key === 'Escape') { e.preventDefault(); closeModal(); }
-      });
-
-      document.querySelectorAll('form.analyze-form').forEach(f => {
-        f.addEventListener('submit', function(ev) {
-          ev.preventDefault();
-          openModal();
-          const data = new FormData(f);
-          fetch(f.action, {method: 'POST', body: data})
-            .then(resp => resp.text().then(() => resp.url))
-            .then(url => { setTimeout(() => { closeModal(); window.location.href = url; }, 1000); });
-        });
-      });
-    });
-  </script>
-  <script src="{{ url_for('static', filename='js/main.js') }}"></script>
-  {% include "partials/footer.html" %}
+    <!-- JavaScript -->
+    <script src="{{ url_for('static', filename='js/main-overlay-test.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/analysis-modal.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `main.html` with overlay/mobile-first layout and analysis modal
- migrate 404 page styles to static CSS
- refactor gallery scripts to external JS
- update finalised/locked pages for new script
- adjust overlay test templates to extend new main layout

## Testing
- `pytest -q` *(fails: import file mismatch errors)*

------
https://chatgpt.com/codex/tasks/task_e_687acc877284832eb972fae7a2cb35d4