### PR TITLE
Remove broken admin menu link

### DIFF
--- a/templates/codex-library/Overlay-Menu-Design-Template/edit_prompts.html
+++ b/templates/codex-library/Overlay-Menu-Design-Template/edit_prompts.html
@@ -1,4 +1,4 @@
-{% extends "main-design-teplate.html" %}
+{% extends "codex-library/Overlay-Menu-Design-Template/main-design-template.html" %}
 {% block title %}Edit Gemini Prompts{% endblock %}
 
 {% block content %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -73,7 +73,7 @@
                     <li><a href="{{ url_for('exports.sellbrite_exports') }}">Sellbrite Exports</a></li>
                     <li><a href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
                     <li><a href="{{ url_for('admin.security_page') }}">Admin Security</a></li>
-                    <li><a href="{{ url_for('admin.users_page') }}">Admin Users</a></li>
+                    {# Removed broken menu link: Admin Users (no such route exists) #}
                     <li><a href="{{ url_for('auth.login') }}">Login</a></li>
                 </ul>
             </div>
@@ -150,7 +150,7 @@
                     <li><a href="{{ url_for('exports.sellbrite_exports') }}">Sellbrite Exports</a></li>
                     <li><a href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
                     <li><a href="{{ url_for('admin.security_page') }}">Admin Security</a></li>
-                    <li><a href="{{ url_for('admin.users_page') }}">Admin Users</a></li>
+                    {# Removed broken menu link: Admin Users (no such route exists) #}
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- comment out broken admin.users_page link in main menu
- fix template path for `edit_prompts.html`

## Testing
- `python - <<'PY' ...` to render all templates
- `pytest -q` *(fails: ModuleNotFoundError due to test import path issues)*
- `git push origin master` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ad79a1b38832eb2557dbd7494ff57