### PR TITLE
Implement responsive container layout

### DIFF
--- a/static/css/404.css
+++ b/static/css/404.css
@@ -9,6 +9,27 @@ body {
     height: 100vh;
     margin: 0;
 }
+
+/* --- Universal Content Container --- */
+.container {
+    max-width: 2400px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.5rem 2rem;
+    box-sizing: border-box;
+}
+@media (max-width: 1800px) {
+    .container { max-width: 98vw; }
+}
+@media (max-width: 1400px) {
+    .container { max-width: 99vw; }
+}
+@media (max-width: 1000px) {
+    .container { padding: 1.8rem 1rem; }
+}
+@media (max-width: 700px) {
+    .container { padding: 1.2rem 0.5rem; }
+}
 h1 {
     font-size: 3em;
     color: #FF6347;

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -4,6 +4,27 @@
    Last updated: 2025-07-20
    ===================================== */
 
+/* --- Universal Content Container (override if needed) --- */
+.container {
+  max-width: 2400px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2.5rem 2rem;
+  box-sizing: border-box;
+}
+@media (max-width: 1800px) {
+  .container { max-width: 98vw; }
+}
+@media (max-width: 1400px) {
+  .container { max-width: 99vw; }
+}
+@media (max-width: 1000px) {
+  .container { padding: 1.8rem 1rem; }
+}
+@media (max-width: 700px) {
+  .container { padding: 1.2rem 0.5rem; }
+}
+
 /* 1. Example: Card layouts used on non-main.html templates */
 .artwork-info-card {
   background: #fcfcfc;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,9 +86,30 @@
             color: inherit; /* Ensure buttons inherit color */
         }
         
-        main {
-            flex-grow: 1;
-        }
+main {
+    flex-grow: 1;
+}
+
+/* --- Universal Content Container --- */
+.container {
+    max-width: 2400px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2.5rem 2rem;
+    box-sizing: border-box;
+}
+@media (max-width: 1800px) {
+    .container { max-width: 98vw; }
+}
+@media (max-width: 1400px) {
+    .container { max-width: 99vw; }
+}
+@media (max-width: 1000px) {
+    .container { padding: 1.8rem 1rem; }
+}
+@media (max-width: 700px) {
+    .container { padding: 1.2rem 0.5rem; }
+}
 
         /* --- Header --- */
         .site-header, .overlay-header {

--- a/templates/404.html
+++ b/templates/404.html
@@ -7,8 +7,10 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/404.css') }}">
 </head>
 <body>
-    <h1>Oops! Something went wrong...</h1>
-    <p>It looks like the page you're looking for has either moved or doesn't exist. Don't worry, it's probably not your fault!</p>
-    <p>Why not head back to the <a href="/">homepage</a> and try again?</p>
+    <div class="container">
+        <h1>Oops! Something went wrong...</h1>
+        <p>It looks like the page you're looking for has either moved or doesn't exist. Don't worry, it's probably not your fault!</p>
+        <p>Why not head back to the <a href="/">homepage</a> and try again?</p>
+    </div>
 </body>
 </html>

--- a/templates/artworks.html
+++ b/templates/artworks.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Artwork | ArtNarrator{% endblock %}
 {% block content %}
+<div class="container">
 
 <div class="page-title-row">
   <img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="hero-step-icon" alt="Step 2: Artwork" />
@@ -74,4 +75,5 @@
 
 </div>
 
+</div>
 {% endblock %}

--- a/templates/composites_preview.html
+++ b/templates/composites_preview.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Composite Preview | ArtNarrator{% endblock %}
 {% block content %}
+<div class="container">
 <h1 style="text-align:center;">Composite Preview: {{ seo_folder }}</h1>
 {% if listing %}
   <div style="text-align:center;margin-bottom:1.5em;">
@@ -33,5 +34,6 @@
 {% endif %}
 <div style="text-align:center;margin-top:2em;">
   <a href="{{ url_for('artwork.select') }}" class="composite-btn" style="background:#666;">Back to Selector</a>
+</div>
 </div>
 {% endblock %}

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Edit Listing{% endblock %}
 {% block content %}
+<div class="container">
 
 <div class="review-artwork-grid row">
   <!-- === Mockup Column === -->
@@ -170,6 +171,6 @@
   <button id="carousel-next" class="carousel-nav" aria-label="Next">&#10095;</button>
 </div>
 
-
+</div>
 <script src="{{ url_for('static', filename='js/edit_listing.js') }}"></script>
 {% endblock %}

--- a/templates/finalised.html
+++ b/templates/finalised.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Finalised Artworks{% endblock %}
 {% block content %}
+<div class="container">
 <div class="page-title-row">
   <img src="{{ url_for('static', filename='icons/svg/light/number-circle-four-light.svg') }}" class="hero-step-icon" alt="Step 4: Finalised" />
   <h1>Finalised Artworks</h1>
@@ -89,4 +90,5 @@
   <div class="modal-img"><img id="final-modal-img" src="" alt="Full image"/></div>
 </div>
 <script src="{{ url_for('static', filename='js/gallery.js') }}"></script>
+</div>
 {% endblock %}

--- a/templates/gallery.html
+++ b/templates/gallery.html
@@ -1,0 +1,4 @@
+
+<div class="container">
+
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}ArtNarrator Home{% endblock %}
 {% block content %}
+<div class="container">
 
 <!-- ========== [IN.1] Home Hero Section ========== -->
 <div class="home-hero">
@@ -54,4 +55,5 @@
     <li><b>Export:</b> Coming soon! Blast your art onto Sellbrite and more with one click.</li>
   </ol>
 </section>
+</div>
 {% endblock %}

--- a/templates/locked.html
+++ b/templates/locked.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Locked Artworks{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Locked Artworks</h1>
 <p class="help-tip">These artworks are locked and cannot be edited until unlocked.</p>
 <div class="view-toggle">
@@ -76,4 +77,5 @@
   <div class="modal-img"><img id="final-modal-img" src="" alt="Full image"/></div>
 </div>
 <script src="{{ url_for('static', filename='js/gallery.js') }}"></script>
+</div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,7 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Login{% endblock %}
 {% block content %}
-<div class="login-container">
+<div class="container">
   <h1>Login</h1>
   {% with msgs = get_flashed_messages(with_categories=true) %}
     {% if msgs %}

--- a/templates/main.html
+++ b/templates/main.html
@@ -84,14 +84,16 @@
 
     <!-- Main Content -->
     <main>
-        {% with messages = get_flashed_messages() %}
-            {% if messages %}
-                <div class="flash">
-                    {% for m in messages %}{{ m }}{% endfor %}
-                </div>
-            {% endif %}
-        {% endwith %}
-        {% block content %}{% endblock %}
+        <div class="container">
+            {% with messages = get_flashed_messages() %}
+                {% if messages %}
+                    <div class="flash">
+                        {% for m in messages %}{{ m }}{% endfor %}
+                    </div>
+                {% endif %}
+            {% endwith %}
+            {% block content %}{% endblock %}
+        </div>
     </main>
 
     <!-- Gemini Modal -->

--- a/templates/mockup_selector.html
+++ b/templates/mockup_selector.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Select Mockups | ArtNarrator{% endblock %}
 {% block content %}
+<div class="container">
 <h1>🖼️ Select Your Mockup Lineup</h1>
 <div class="grid">
   {% for slot, options in zipped %}
@@ -38,5 +39,6 @@
   {% else %}
     <a href="{{ url_for('artwork.composites_preview') }}" class="composite-btn" style="background:#666;">👁️ Preview Composites</a>
   {% endif %}
+</div>
 </div>
 {% endblock %}

--- a/templates/review.html
+++ b/templates/review.html
@@ -2,6 +2,7 @@
 {% extends "main.html" %}
 {% block title %}Review | ArtNarrator{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Review &amp; Approve Listing</h1>
 <section class="review-artwork">
   <h2>{{ artwork.title }}</h2>
@@ -31,5 +32,6 @@
 </form>
 <div style="text-align:center;margin-top:1.5em;">
   <a href="{{ url_for('artwork.composites_specific', seo_folder=artwork.seo_name) }}" class="composite-btn" style="background:#666;">Preview Composites</a>
+</div>
 </div>
 {% endblock %}

--- a/templates/sellbrite_csv_preview.html
+++ b/templates/sellbrite_csv_preview.html
@@ -1,6 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Preview {{ csv_filename }}{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Preview {{ csv_filename }}</h1>
 <p><a class="btn-black" href="{{ url_for('exports.download_sellbrite', csv_filename=csv_filename) }}">Download Full CSV</a></p>
 <div class="csv-preview">
@@ -16,5 +17,6 @@
       {% endfor %}
     </tbody>
   </table>
+</div>
 </div>
 {% endblock %}

--- a/templates/sellbrite_exports.html
+++ b/templates/sellbrite_exports.html
@@ -1,6 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Sellbrite Exports{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Sellbrite Exports</h1>
 <p class="help-tip">Review all previous exports below. Warnings show missing fields or short descriptions.</p>
 <div class="export-actions">
@@ -27,4 +28,5 @@
   {% endfor %}
   </tbody>
 </table>
+</div>
 {% endblock %}

--- a/templates/sellbrite_log.html
+++ b/templates/sellbrite_log.html
@@ -1,6 +1,8 @@
 {% extends "main.html" %}
 {% block title %}Export Log{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Export Log {{ log_filename }}</h1>
 <pre class="export-log">{{ log_text }}</pre>
+</div>
 {% endblock %}

--- a/templates/test_description.html
+++ b/templates/test_description.html
@@ -1,8 +1,10 @@
 {% extends "main.html" %}
 {% block title %}Test Combined Description{% endblock %}
 {% block content %}
+<div class="container">
 <h1>Test Combined Description</h1>
 <div class="desc-text" style="white-space: pre-wrap;border:1px solid #ccc;padding:10px;">
   {{ combined_description }}
+</div>
 </div>
 {% endblock %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,6 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Upload Artwork{% endblock %}
 {% block content %}
+<div class="container">
 <div class="page-title-row" >
   <img src="{{ url_for('static', filename='icons/svg/light/number-circle-one-light.svg') }}" class="hero-step-icon" alt="Step 1: Upload" />
   <h1>Upload New Artwork</h1>
@@ -13,4 +14,5 @@
   <ul id="upload-list" class="upload-list"></ul>
 </form>
 <script src="{{ url_for('static', filename='js/upload.js') }}"></script>
+</div>
 {% endblock %}

--- a/templates/upload_results.html
+++ b/templates/upload_results.html
@@ -1,6 +1,7 @@
 {% extends "main.html" %}
 {% block title %}Upload Results{% endblock %}
 {% block content %}
+<div class="container">
 <h2 class="mb-3">Upload Summary</h2>
 <ul>
   {% for r in results %}
@@ -8,4 +9,5 @@
   {% endfor %}
 </ul>
 <a href="{{ url_for('artwork.artworks') }}" class="btn btn-primary">Return to Gallery</a>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- create a universal `.container` CSS block
- wrap page content in `.container` across templates
- keep base layout consistent

## Testing
- `pytest -q` *(fails: Failed loading /composites)*

------
https://chatgpt.com/codex/tasks/task_e_687bf8b848dc832eb92dfa5516efba75