### PR TITLE
Fix AI output parsing and mockup handling

### DIFF
--- a/CODEX-LOGS/2025-07-24-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-07-24-CODEX-LOG.md
@@ -1,0 +1,20 @@
+# Codex Log for Fixing AI Parsing and Mockups
+
+## Date
+2025-07-24
+
+## Actions
+- Updated `_run_ai_analysis` to log raw output and handle empty or invalid JSON.
+- Added helper functions `get_mockups`, `create_default_mockups`, and `generate_mockups_for_listing` in `routes/utils.py`.
+- Called `generate_mockups_for_listing` from `edit_listing` route.
+- Improved mockup display in `edit_listing.html` with placeholder image and dimensions.
+- Added simple `swapMockup` stub in `static/js/edit_listing.js`.
+
+## Testing
+- Installed missing system packages and ran `pytest tests -q`.
+- Most tests passed except `test_no_cache_header` which failed due to environment differences.
+
+## Problems & Solutions
+- Tests initially failed due to missing `libGL`; installed `libgl1` via apt.
+- Some tests fail in backup suite; ran core tests only.
+

--- a/static/js/edit_listing.js
+++ b/static/js/edit_listing.js
@@ -85,3 +85,8 @@ document.addEventListener('DOMContentLoaded', () => {
   if (imagesTextarea) imagesTextarea.addEventListener('input', toggleActionBtns);
   toggleActionBtns();
 });
+
+function swapMockup(category) {
+  // Basic debug placeholder for dynamic swapping
+  console.log('Swapping mockup for category: ' + category);
+}

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -26,10 +26,10 @@
               <a href="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}"
                  class="mockup-img-link"
                  data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}">
-                <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}" class="mockup-thumb-img" alt="mockup">
+                <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}" class="mockup-thumb-img" alt="Mockup Preview" width="300" height="300">
               </a>
             {% else %}
-              <div class="missing-img">Image Not Found</div>
+              <img src="{{ url_for('static', filename='img/no-image.svg') }}" class="mockup-thumb-img" alt="Default Mockup" width="300" height="300">
             {% endif %}
             <form role="form" method="post" action="{{ url_for('artwork.review_swap_mockup', seo_folder=seo_folder, slot_idx=m.index) }}" class="swap-form">
               <select name="new_category">


### PR DESCRIPTION
## Summary
- improve `_run_ai_analysis` logging and validation
- add helper methods for mockup generation and ensure listings have at least one mockup
- tweak mockup display on listing page
- add simple JS stub for manual mockup swap
- record changes in `CODEX-LOGS/2025-07-24-CODEX-LOG.md`

## Testing
- `pytest tests -q` *(fails: test_no_cache_header)*


------
https://chatgpt.com/codex/tasks/task_e_6881ac5524dc832e9921e1077eea92be