### PR TITLE
Fix analyze API route

### DIFF
--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -1607,7 +1607,7 @@ def push_sellbrite_placeholder(aspect, filename):
     return redirect(url_for("artwork.finalised_gallery"))
 
 
-@bp.post("/analyze/<provider>/<filename>")
+@bp.post("/analyze-<provider>/<filename>")
 def analyze_api(provider: str, filename: str):
     """Analyze an artwork then redirect or return JSON for editing."""
 


### PR DESCRIPTION
## Summary
- fix analyze API route path to use hyphen and provider parameter

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: import file mismatch)*
- `FLASK_APP=app.py flask run -p 5001 &`

------
https://chatgpt.com/codex/tasks/task_e_6882cb4dd76c832ebc56ca1bca92d838