### PR TITLE
Fix swap forms on edit_listing page

### DIFF
--- a/CODEX-LOGS/2025-07-26-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-07-26-CODEX-LOG.md
@@ -1,0 +1,12 @@
+# Codex Log - Swap Form Fix
+
+- **Date:** 2025-07-26T09:13:30+00:00
+- **Files Modified:** `templates/edit_listing.html`
+- **Reason:** Remove broken onclick handler; make swap forms POST properly.
+- **Commands:**
+  - `pip install ImageHash`
+  - `apt-get install libgl1`
+  - `pytest tests/test_routes.py -q`
+  - `pytest tests/test_upload.py -q`
+  - `pytest tests/test_registry.py -q`
+- **Outcome:** Selected tests pass. Full suite fails due to missing env packages and file mismatches.

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -51,13 +51,14 @@
               <img src="{{ url_for('static', filename='img/default-mockup.jpg') }}" class="mockup-thumb-img" alt="Default mockup placeholder">
             {% endif %}
             {% if categories %}
+              {# -- TODO: Upgrade to AJAX-based swap preview in edit_listing.js -- #}
               <form role="form" method="post" action="{{ url_for('artwork.review_swap_mockup', seo_folder=seo_folder, slot_idx=m.index) }}" class="swap-form">
                 <select name="new_category" aria-label="Swap mockup category for mockup {{ loop.index }}">
                   {% for c in categories %}
                     <option value="{{ c }}" {% if c == m.category %}selected{% endif %}>{{ c }}</option>
                   {% endfor %}
                 </select>
-                <button type="submit" class="btn btn-sm" onclick="swapMockup('{{ m.category }}')">Swap</button>
+                <button type="submit" class="btn btn-sm">Swap</button>
               </form>
             {% else %}
               <div class="no-categories-warning">No categories found.</div>


### PR DESCRIPTION
## Summary
- fix broken swap button forms in `edit_listing.html`
- log changes in CODEX log

## Testing
- `pytest tests/test_routes.py -q`
- `pytest tests/test_upload.py -q`
- `pytest tests/test_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68849af49ae4832eaed5235e1631c477