### PR TITLE
Serve processed mockup thumbs

### DIFF
--- a/CODEX-LOGS/2025-07-26-CODEX-LOG2.md
+++ b/CODEX-LOGS/2025-07-26-CODEX-LOG2.md
@@ -1,0 +1,10 @@
+# Codex Log - Mockup Thumb Route Fix
+
+- **Date:** 2025-07-26T09:36:30+00:00
+- **Files Modified:** `routes/artwork_routes.py`, `templates/edit_listing.html`
+- **Reason:** Serve mockup thumbnails from processed folders and display them correctly.
+- **Commands:**
+  - `apt-get install -y libgl1`
+  - `pip install ImageHash`
+  - `pytest tests/test_routes.py -q`
+- **Outcome:** Route tests pass after installing dependencies.

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -1213,6 +1213,13 @@ def locked_image(seo_folder, filename):
     return send_from_directory(folder, filename)
 
 
+@bp.route("/thumbs/<seo_folder>/<filename>")
+def serve_mockup_thumb(seo_folder: str, filename: str):
+    """Serve mockup thumbnails from the THUMBS directory."""
+    thumb_folder = utils.PROCESSED_ROOT / seo_folder / "THUMBS"
+    return send_from_directory(thumb_folder, filename)
+
+
 @bp.route("/artwork-img/<aspect>/<filename>")
 def artwork_image(aspect, filename):
     folder = utils.UNANALYSED_ROOT / aspect

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -41,11 +41,14 @@
         {% for m in mockups %}
           <div class="mockup-card">
             {% if m.exists %}
-              {% set img_name = m.thumb.name if m.thumb_exists else m.path.name %}
               <a href="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}?t={{ cache_ts }}"
                  class="mockup-img-link"
                  data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}?t={{ cache_ts }}">
-                <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=img_name) }}?t={{ cache_ts }}" class="mockup-thumb-img" alt="Mockup preview {{ loop.index }}">
+                {% if m.thumb_exists %}
+                  <img src="{{ url_for('artwork.serve_mockup_thumb', seo_folder=seo_folder, filename=m.thumb.name) }}?t={{ cache_ts }}" class="mockup-thumb-img" alt="Mockup preview {{ loop.index }}">
+                {% else %}
+                  <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=m.path.name) }}?t={{ cache_ts }}" class="mockup-thumb-img" alt="Mockup preview {{ loop.index }}">
+                {% endif %}
               </a>
             {% else %}
               <img src="{{ url_for('static', filename='img/default-mockup.jpg') }}" class="mockup-thumb-img" alt="Default mockup placeholder">


### PR DESCRIPTION
## Summary
- serve thumbnails from `THUMBS` subfolder
- display mockup thumbs on listing page using new route
- record log of actions

## Testing
- `pytest tests/test_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6884a04de36c832eac054b16b26d7192