### PR TITLE
Fix thumbnail loading and swap

### DIFF
--- a/CODEX-LOGS/2025-07-26-CODEX-LOG4.md
+++ b/CODEX-LOGS/2025-07-26-CODEX-LOG4.md
@@ -1,0 +1,8 @@
+# Codex Log for PR
+
+## 2025-07-26
+- Adjusted `edit_listing.html` to load thumbnails from THUMBS via `url_for('static')` with fallback.
+- Added inline flash message block to display swap results.
+- Created `/review-swap-mockup/<seo_folder>/<int:slot_idx>` route in `artwork_routes.py` and simplified logic.
+- Updated swap forms and disabled legacy AJAX in `edit_listing.js`.
+- Attempted `pytest` after installing `opencv-python-headless` and `ImageHash`; tests fail due to env vars.

--- a/static/js/edit_listing.js
+++ b/static/js/edit_listing.js
@@ -42,36 +42,9 @@ document.addEventListener('DOMContentLoaded', () => {
     else if (e.key === 'ArrowRight') show(idx + 1);
   });
 
+
   /* --------- [ EL2. Swap Mockup Forms ] --------- */
-  document.querySelectorAll('.swap-form').forEach(form => {
-    form.addEventListener('submit', ev => {
-      ev.preventDefault();
-      const sel = form.querySelector('select[name="new_category"]');
-      const data = new FormData();
-      data.append('new_category', sel.value);
-      fetch(form.action, {
-        method: 'POST',
-        body: data,
-        headers: { 'X-Requested-With': 'XMLHttpRequest' }
-      })
-      .then(r => r.json())
-      .then(d => {
-        if (d.success && d.img_url) {
-          const card = form.closest('.mockup-card');
-          const img = card.querySelector('.mockup-thumb-img');
-          if (img) img.src = d.img_url + '?t=' + Date.now();
-          const link = card.querySelector('.mockup-img-link');
-          if (link) {
-            link.href = d.img_url;
-            link.dataset.img = d.img_url;
-          }
-        } else {
-          window.location.reload();
-        }
-      })
-      .catch(() => window.location.reload());
-    });
-  });
+  // Legacy AJAX swap disabled; form now submits normally to backend
 
   /* --------- [ EL3. Enable Action Buttons ] --------- */
   function toggleActionBtns() {

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -11,11 +11,25 @@
     <h1><img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="hero-step-icon" alt="Step 3: Edit Listing" />Edit Listing</h1>
   </div>
 
+  {% with msgs = get_flashed_messages(with_categories=true) %}
+    {% if msgs %}
+      <div class="flash-block">
+        {% for cat, msg in msgs %}
+          <div class="flash-{{ cat }}">{{ msg }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
   <div class="review-artwork-grid row">
     <div class="col col-6 mockup-col">
       <div class="main-thumb">
-        <a href="#" class="main-thumb-link" data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder+'.jpg') }}?t={{ cache_ts }}">
-          <img src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder+'-THUMB.jpg') }}?t={{ cache_ts }}" class="main-artwork-thumb" alt="Main artwork thumbnail for {{ seo_folder }}">
+        {% set m_thumb = 'art-processing/processed-artwork/' + seo_folder + '/THUMBS/' + seo_folder + '-thumb.jpg' %}
+        {% set m_full = 'art-processing/processed-artwork/' + seo_folder + '/' + seo_folder + '.jpg' %}
+        <a href="#" class="main-thumb-link" data-img="{{ url_for('static', filename=m_full) }}?t={{ cache_ts }}">
+          <img src="{{ url_for('static', filename=m_thumb) }}?t={{ cache_ts }}"
+               onerror="this.onerror=null; this.src='{{ url_for('static', filename=m_full) }}?t={{ cache_ts }}';"
+               class="main-artwork-thumb" alt="Main artwork thumbnail for {{ seo_folder }}">
         </a>
         <div class="thumb-note">Click thumbnail for full size</div>
       </div>


### PR DESCRIPTION
## Summary
- load thumbnails from THUMBS using `url_for('static')`
- show flash messages in edit listing page
- simplify JS by removing broken ajax swap handling
- create `/review-swap-mockup/<seo_folder>/<int:slot_idx>` route
- document work in new log

## Testing
- `pytest tests/test_routes.py -q` *(fails: OPENAI_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_e_6884b2acc3c8832e9a529e73afd6985f