### PR TITLE
Implement async mockup swap workflow

### DIFF
--- a/CODEX-LOGS/2025-07-27-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-07-27-CODEX-LOG.md
@@ -1,0 +1,19 @@
+# Codex Log
+
+## Date
+Sun Jul 27 02:37:38 UTC 2025
+
+## Summary
+- Implemented mockup thumbnail swap workflow with AJAX.
+- Restored and updated `edit_listing.js` for carousel and async swap.
+- Updated `edit_listing.html` with thumb paths, swap forms, and global JS vars.
+- Added new blueprint `edit_listing_routes.py` with `/swap-mockup` endpoint.
+- Updated utilities to handle mockup swap with thumbnail regeneration.
+- Added single-mode option to `generate_composites.py`.
+- Adjusted category scanning logic.
+- Registered new blueprint in `app.py`.
+- Tests executed after installing opencv-python-headless and ImageHash.
+
+## Testing
+- `pytest tests -q` → all tests passed.
+

--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ from routes.coordinate_admin_routes import bp as coordinate_admin_bp
 from routes.gdws_admin_routes import bp as gdws_admin_bp
 from routes.test_routes import test_bp
 from routes.api_routes import bp as api_bp
+from routes.edit_listing_routes import bp as edit_listing_bp
 
 # ---- Initialize Flask App ----
 app = Flask(__name__)
@@ -122,6 +123,7 @@ app.register_blueprint(coordinate_admin_bp)
 app.register_blueprint(gdws_admin_bp)
 app.register_blueprint(test_bp)
 app.register_blueprint(api_bp)
+app.register_blueprint(edit_listing_bp)
 
 
 @app.after_request

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -363,16 +363,12 @@ def get_categories_for_aspect(aspect: str) -> list[str]:
     logger = logging.getLogger(__name__)
     logger.debug("[DEBUG] get_categories_for_aspect: aspect=%s", aspect)
 
-    base = config.MOCKUPS_CATEGORISED_DIR / f"{aspect}-categorised"
+    base = config.MOCKUPS_CATEGORISED_DIR / aspect
     if not base.exists():
         logger.warning("[DEBUG] Category folder missing: %s", base)
-        base = config.MOCKUPS_CATEGORISED_DIR / "4x5-categorised"
-        if not base.exists():
-            logger.error("[DEBUG] Default category folder also missing: %s", base)
-            return []
+        return []
 
-    cats = [f.name for f in base.iterdir() if f.is_dir()]
-    cats = sorted(cats)[:25]
+    cats = sorted([f.name for f in base.iterdir() if f.is_dir()])
     logger.debug("[DEBUG] categories resolved: %s", cats)
     return cats
 
@@ -855,7 +851,7 @@ def review_swap_mockup(seo_folder, slot_idx):
     new_category = request.form.get("new_category")
     logger = logging.getLogger(__name__)
     logger.info("Swapping mockup %s slot %s to %s", seo_folder, slot_idx, new_category)
-    success = utils.swap_one_mockup(seo_folder, slot_idx, new_category)
+    success, *_ = utils.swap_one_mockup(seo_folder, slot_idx, new_category)
     if success:
         flash(f"Mockup slot {slot_idx} swapped to {new_category}", "success")
     else:

--- a/routes/edit_listing_routes.py
+++ b/routes/edit_listing_routes.py
@@ -1,0 +1,35 @@
+"""Routes for interactive edit-listing actions."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request, jsonify, url_for
+
+from routes import utils
+
+bp = Blueprint("edit_listing", __name__)
+
+
+@bp.route("/swap-mockup", methods=["POST"])
+def swap_mockup():
+    """Swap a mockup via AJAX and return new file paths."""
+    data = request.get_json(silent=True) or {}
+    seo = data.get("seo_filename", "").strip()
+    aspect = data.get("aspect_ratio", "").strip()
+    slot = int(data.get("slot_index", 0))
+    category = data.get("category", "").strip()
+
+    if not seo or not aspect or not category:
+        return jsonify(success=False, error="Invalid parameters"), 400
+
+    success, new_mockup, new_thumb = utils.swap_one_mockup(seo, slot, category)
+    if not success:
+        return jsonify(success=False, error="Swap failed"), 500
+
+    thumb_path = f"art-processing/processed-artwork/{seo}/THUMBS/{new_thumb}"
+    full_path = f"art-processing/processed-artwork/{seo}/{new_mockup}"
+
+    return jsonify(
+        success=True,
+        new_full=url_for("static", filename=full_path),
+        new_thumb=url_for("static", filename=thumb_path),
+    )

--- a/static/js/edit_listing.js
+++ b/static/js/edit_listing.js
@@ -1,222 +1,109 @@
-{# -- templates/edit_listing.html -- #}
-{% extends "main.html" %}
-{% block title %}Edit Listing{% endblock %}
+/* ==============================
+   ArtNarrator Edit Listing JS
+   ============================== */
 
-{% block content %}
-<style>
-  .action-form { width: 100%; }
-  .form-col { flex: 1; }
-</style>
+/* --------- [ EL1. Carousel Modal ] --------- */
+document.addEventListener('DOMContentLoaded', () => {
+  const carousel = document.getElementById('mockup-carousel');
+  const imgEl = document.getElementById('carousel-img');
+  const closeBtn = document.getElementById('carousel-close');
+  const prevBtn = document.getElementById('carousel-prev');
+  const nextBtn = document.getElementById('carousel-next');
 
-<div class="container">
-  <div class="home-hero">
-    <h1>
-      <img src="{{ url_for('static', filename='icons/svg/light/number-circle-three-light.svg') }}" class="hero-step-icon" alt="Step 3 Icon">
-      Edit Listing
-    </h1>
-  </div>
+  const links = Array.from(document.querySelectorAll('.mockup-img-link'));
+  const thumb = document.querySelector('.main-thumb-link');
+  if (thumb) links.unshift(thumb);
+  const images = links.map(l => l.dataset.img);
+  let idx = 0;
 
-  {# -- Flash messages -- #}
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      <div class="flash-message-block">
-        {% for category, message in messages %}
-          <div class="flash flash-{{ category }}">{{ message }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+  function show(i) {
+    idx = (i + images.length) % images.length;
+    imgEl.src = images[idx];
+    carousel.classList.add('active');
+  }
+  function close() {
+    carousel.classList.remove('active');
+    imgEl.src = '';
+  }
+  links.forEach((link, i) => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      show(i);
+    });
+  });
+  if (closeBtn) closeBtn.onclick = close;
+  if (prevBtn) prevBtn.onclick = () => show(idx - 1);
+  if (nextBtn) nextBtn.onclick = () => show(idx + 1);
+  if (carousel) carousel.addEventListener('click', e => { if (e.target === carousel) close(); });
+  document.addEventListener('keydown', e => {
+    if (!carousel.classList.contains('active')) return;
+    if (e.key === 'Escape') close();
+    else if (e.key === 'ArrowLeft') show(idx - 1);
+    else if (e.key === 'ArrowRight') show(idx + 1);
+  });
 
-  <div class="review-artwork-grid row">
-    <!-- === LEFT: Artwork & Mockups === -->
-    <div class="col col-6 mockup-col">
-      <div class="main-thumb">
-        <a href="#"
-           class="main-thumb-link"
-           data-img="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder ~ '.jpg') }}?t={{ cache_ts }}">
-          <img
-            src="{{ url_for('artwork.processed_image', seo_folder=seo_folder, filename=seo_folder ~ '-THUMB.jpg') }}?t={{ cache_ts }}"
-            class="main-artwork-thumb"
-            alt="Main artwork thumbnail for {{ seo_folder }}">
-        </a>
-        <div class="thumb-note">Click thumbnail for full size</div>
-      </div>
 
-      <h3>Preview Mockups</h3>
-      <div class="debug-categories">
-        <strong>Categories:</strong>
-        {{ categories | join(', ') if categories else 'none' }}
-      </div>
+  /* --------- [ EL2. Swap Mockup Forms ] --------- */
+  const swapButtons = document.querySelectorAll('.swap-btn');
 
-      <div class="mockup-preview-grid">
-        {% for m in mockups %}
-          <div class="mockup-card">
-            {% if m.exists %}
-              {% set thumb_name = m.path.stem ~ '-thumb.jpg' %}
-              {% set thumb_path = 'art-processing/processed-artwork/' ~ seo_folder ~ '/THUMBS/' ~ thumb_name %}
-              {% set full_path = 'art-processing/processed-artwork/' ~ seo_folder ~ '/' ~ m.path.name %}
+  async function swapMockup(slot) {
+    const form = document.getElementById(`swap-form-${slot}`);
+    if (!form) return;
+    const select = form.querySelector('select');
+    const btn = form.querySelector('button');
+    btn.disabled = true;
 
-              <a href="{{ url_for('static', filename=full_path) }}?t={{ cache_ts }}"
-                 class="mockup-img-link"
-                 data-img="{{ url_for('static', filename=full_path) }}?t={{ cache_ts }}">
-                <img 
-                  src="{{ url_for('static', filename=thumb_path) }}?t={{ cache_ts }}"
-                  onerror="this.onerror=null; this.src='{{ url_for('static', filename=full_path) }}?t={{ cache_ts }}';"
-                  class="mockup-thumb-img"
-                  alt="Mockup preview {{ loop.index }}">
-              </a>
-            {% else %}
-              <img src="{{ url_for('static', filename='img/default-mockup.jpg') }}"
-                   class="mockup-thumb-img"
-                   alt="Default mockup placeholder">
-            {% endif %}
+    const payload = {
+      seo_filename: window.EDIT_INFO.seoFolder,
+      aspect_ratio: window.EDIT_INFO.aspect,
+      slot_index: slot,
+      category: select.value
+    };
 
-            {% if categories %}
-              <form method="post"
-                    action="{{ url_for('artwork.review_swap_mockup', seo_folder=seo_folder, slot_idx=m.index) }}"
-                    class="swap-form">
-                <select name="new_category" aria-label="Swap mockup category for slot {{ m.index }}">
-                  {% for c in categories %}
-                    <option value="{{ c }}" {% if c == m.category %}selected{% endif %}>{{ c }}</option>
-                  {% endfor %}
-                </select>
-                <button type="submit" class="btn btn-sm">Swap</button>
-              </form>
-            {% else %}
-              <div class="no-categories-warning">No categories found.</div>
-            {% endif %}
-          </div>
-        {% endfor %}
-      </div>
-    </div>
+    try {
+      const res = await fetch('/swap-mockup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const data = await res.json();
+      if (data.success) {
+        const img = document.getElementById(`mockup-img-${slot}`);
+        const link = document.getElementById(`mockup-link-${slot}`);
+        const ts = Date.now();
+        if (img) img.src = data.new_thumb + '?t=' + ts;
+        if (link) {
+          link.dataset.img = data.new_full + '?t=' + ts;
+          link.href = data.new_full + '?t=' + ts;
+        }
+      } else {
+        alert(data.error || 'Failed to swap mockup');
+      }
+    } catch (err) {
+      console.error('Swap error', err);
+      alert('Error swapping mockup');
+    }
 
-    <!-- === RIGHT: Edit Metadata Form === -->
-    <div class="col col-6 edit-listing-col">
-      <p class="status-line {% if finalised %}status-finalised{% else %}status-pending{% endif %}">
-        Status: {% if finalised %}<strong>finalised</strong>{% else %}<em>NOT yet finalised</em>{% endif %}
-        {% if locked %}<span class="locked-badge">Locked</span>{% endif %}
-      </p>
+    btn.disabled = false;
+  }
 
-      {% if errors %}
-        <div class="flash-error"><ul>{% for e in errors %}<li>{{ e }}</li>{% endfor %}</ul></div>
-      {% endif %}
+  swapButtons.forEach((btn, idx) => {
+    btn.addEventListener('click', e => {
+      e.preventDefault();
+      swapMockup(idx);
+    });
+  });
 
-      <form id="edit-form" method="POST" autocomplete="off">
-        <label for="title-input">Title:</label>
-        <textarea name="title" id="title-input" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.title|e }}</textarea>
+  /* --------- [ EL3. Enable Action Buttons ] --------- */
+  function toggleActionBtns() {
+    const txt = document.querySelector('textarea[name="images"]');
+    const disabled = !(txt && txt.value.trim());
+    document.querySelectorAll('.require-images').forEach(btn => {
+      btn.disabled = disabled;
+    });
+  }
+  const imagesTextarea = document.querySelector('textarea[name="images"]');
+  if (imagesTextarea) imagesTextarea.addEventListener('input', toggleActionBtns);
+  toggleActionBtns();
+});
 
-        <label for="description-input">Description:</label>
-        <textarea name="description" id="description-input" rows="12" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.description|e }}</textarea>
-
-        <label for="tags-input">Tags (comma-separated):</label>
-        <textarea name="tags" id="tags-input" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.tags|e }}</textarea>
-
-        <label for="materials-input">Materials (comma-separated):</label>
-        <textarea name="materials" id="materials-input" rows="2" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.materials|e }}</textarea>
-
-        <div class="row-inline">
-          <div class="form-col">
-            <label for="primary_colour-select">Primary Colour:</label>
-            <select name="primary_colour" id="primary_colour-select" class="long-field" {% if not editable %}disabled{% endif %}>
-              {% for col in colour_options %}
-                <option value="{{ col }}" {% if artwork.primary_colour==col %}selected{% endif %}>{{ col }}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="form-col">
-            <label for="secondary_colour-select">Secondary Colour:</label>
-            <select name="secondary_colour" id="secondary_colour-select" class="long-field" {% if not editable %}disabled{% endif %}>
-              {% for col in colour_options %}
-                <option value="{{ col }}" {% if artwork.secondary_colour==col %}selected{% endif %}>{{ col }}</option>
-              {% endfor %}
-            </select>
-          </div>
-        </div>
-
-        <label for="seo_filename-input">SEO Filename:</label>
-        <input type="text" id="seo_filename-input" name="seo_filename" class="long-field" value="{{ artwork.seo_filename|e }}" {% if not editable %}disabled{% endif %}>
-
-        <div class="price-sku-row">
-          <div>
-            <label for="price-input">Price:</label>
-            <input type="text" id="price-input" name="price" value="{{ artwork.price|e }}" class="long-field" {% if not editable %}disabled{% endif %}>
-          </div>
-          <div>
-            <label for="sku-input">SKU:</label>
-            <input type="text" id="sku-input" value="{{ artwork.sku|e }}" class="long-field" readonly disabled>
-          </div>
-        </div>
-
-        <label for="images-input">Image URLs (one per line):</label>
-        <textarea name="images" id="images-input" rows="5" class="long-field" {% if not editable %}disabled{% endif %}>{{ artwork.images|e }}</textarea>
-      </form>
-
-      <div class="edit-actions-col">
-        <button form="edit-form" type="submit" name="action" value="save" class="btn btn-primary wide-btn" {% if not editable %}disabled{% endif %}>Save Changes</button>
-        <button form="edit-form" type="submit" name="action" value="delete" class="btn btn-danger wide-btn" onclick="return confirm('Delete this artwork and all files?');" {% if not editable %}disabled{% endif %}>Delete</button>
-
-        {% if not finalised %}
-          <form method="post" action="{{ url_for('artwork.finalise_artwork', aspect=aspect, filename=filename) }}" class="action-form">
-            <button type="submit" class="btn btn-primary wide-btn">Finalise</button>
-          </form>
-        {% endif %}
-
-        <form method="POST" action="{{ url_for('artwork.analyze_artwork', aspect=aspect, filename=filename) }}" class="action-form analyze-form">
-          <select name="provider" class="form-select form-select-sm mb-2">
-            <option value="openai">OpenAI</option>
-            <option value="google">Google</option>
-          </select>
-          <button type="submit" class="btn btn-primary wide-btn" {% if locked %}disabled{% endif %}>Re-analyse Artwork</button>
-        </form>
-
-        {% if finalised and not locked %}
-          <form method="post" action="{{ url_for('artwork.lock_listing', aspect=aspect, filename=filename) }}" class="action-form">
-            <button type="submit" class="btn btn-primary wide-btn">Lock it in</button>
-          </form>
-        {% elif locked %}
-          <form method="post" action="{{ url_for('artwork.unlock_listing', aspect=aspect, filename=filename) }}" class="action-form">
-            <button type="submit" class="btn btn-primary wide-btn">Unlock</button>
-          </form>
-        {% endif %}
-
-        <form method="post" action="{{ url_for('artwork.reset_sku', aspect=aspect, filename=filename) }}" class="action-form">
-          <button type="submit" class="btn-primary wide-btn" {% if locked %}disabled{% endif %}>Reset SKU</button>
-        </form>
-      </div>
-
-      {% if openai_analysis %}
-        <div class="openai-details">
-          {% set entries = openai_analysis if openai_analysis is iterable and openai_analysis.__class__ != dict else [openai_analysis] %}
-          {% for info in entries %}
-            <table class="openai-analysis-table">
-              <thead><tr><th colspan="2">OpenAI Analysis Details</th></tr></thead>
-              <tbody>
-                <tr><th>Original File</th><td>{{ info.original_file }}</td></tr>
-                <tr><th>Optimized File</th><td>{{ info.optimized_file }}</td></tr>
-                <tr><th>Size</th><td>{{ info.size_mb }} MB ({{ info.size_bytes }} bytes)</td></tr>
-                <tr><th>Dimensions</th><td>{{ info.dimensions }}</td></tr>
-                <tr><th>Time Sent</th><td>{{ info.time_sent }}</td></tr>
-                <tr><th>Time Responded</th><td>{{ info.time_responded }}</td></tr>
-                <tr><th>Duration</th><td>{{ info.duration_sec }} s</td></tr>
-                <tr><th>Status</th><td>{{ info.status }}</td></tr>
-                {% if info.api_response %}<tr><th>API Response</th><td>{{ info.api_response }}</td></tr>{% endif %}
-                {% if info.naming_method %}<tr><th>Naming Method</th><td>{{ info.naming_method }}{% if info.used_fallback_naming %} (fallback){% endif %}</td></tr>{% endif %}
-              </tbody>
-            </table>
-          {% endfor %}
-        </div>
-      {% endif %}
-    </div>
-  </div>
-
-  <!-- === Modal Carousel for Mockups === -->
-  <div id="mockup-carousel" class="modal-bg" tabindex="-1">
-    <button id="carousel-close" class="modal-close" aria-label="Close">&times;</button>
-    <button id="carousel-prev" class="carousel-nav" aria-label="Previous">&#10094;</button>
-    <div class="modal-img"><img id="carousel-img" src="" alt="Mockup Preview" /></div>
-    <button id="carousel-next" class="carousel-nav" aria-label="Next">&#10095;</button>
-  </div>
-</div>
-
-<script src="{{ url_for('static', filename='js/edit_listing.js') }}"></script>
-{% endblock %}

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -46,19 +46,17 @@
   {% for m in mockups %}
     <div class="mockup-card">
       {% if m.exists %}
-        {# -- Precompute full and thumb image paths -- #}
-        {% set thumb_name = m.path.stem + '-thumb.jpg' %}
-        {% set thumb_path = 'art-processing/processed-artwork/' + seo_folder + '/THUMBS/' + thumb_name %}
-        {% set full_path = 'art-processing/processed-artwork/' + seo_folder + '/' + m.path.name %}
-        {% set full_img = url_for('static', filename=full_path) ~ '?t=' ~ cache_ts %}
-        {% set thumb_img = url_for('static', filename=thumb_path) ~ '?t=' ~ cache_ts %}
-
-        <a href="{{ full_img }}"
+        {# -- Precompute image paths -- #}
+        {% set thumb_rel = 'art-processing/processed-artwork/' ~ seo_folder ~ '/THUMBS/' ~ m.thumb.name %}
+        {% set full_rel = 'art-processing/processed-artwork/' ~ seo_folder ~ '/' ~ m.path.name %}
+        <a href="{{ url_for('static', filename=full_rel) ~ '?t=' ~ cache_ts }}"
            class="mockup-img-link"
-           data-img="{{ full_img }}">
-          <img 
-            src="{{ thumb_img }}"
-            onerror="this.onerror=null; this.src='{{ full_img }}';"
+           id="mockup-link-{{ m.index }}"
+           data-img="{{ url_for('static', filename=full_rel) ~ '?t=' ~ cache_ts }}">
+          <img
+            id="mockup-img-{{ m.index }}"
+            src="{{ url_for('static', filename=thumb_rel) ~ '?t=' ~ cache_ts }}"
+            onerror="this.onerror=null; this.src='{{ url_for('static', filename=full_rel) ~ '?t=' ~ cache_ts }}';"
             class="mockup-thumb-img"
             alt="Mockup preview {{ loop.index }}">
         </a>
@@ -71,16 +69,13 @@
       {% endif %}
 
       {% if categories %}
-        <form method="post"
-              action="{{ url_for('artwork.review_swap_mockup', seo_folder=seo_folder, slot_idx=m.index) }}"
-              class="swap-form">
-          <select name="new_category"
-                  aria-label="Swap mockup category for slot {{ m.index }}">
+        <form id="swap-form-{{ m.index }}" class="swap-form" data-file="{{ m.path.name }}">
+          <select name="new_category" aria-label="Swap mockup category for slot {{ m.index }}">
             {% for c in categories %}
               <option value="{{ c }}" {% if c == m.category %}selected{% endif %}>{{ c }}</option>
             {% endfor %}
           </select>
-          <button type="submit" class="btn btn-sm">Swap</button>
+          <button type="button" class="btn btn-sm swap-btn">Swap</button>
         </form>
       {% else %}
         <div class="no-categories-warning">No categories found.</div>
@@ -215,5 +210,11 @@
   </div>
 </div>
 
+<script>
+  window.EDIT_INFO = {
+    seoFolder: '{{ seo_folder }}',
+    aspect: '{{ aspect }}'
+  };
+</script>
 <script src="{{ url_for('static', filename='js/edit_listing.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restore real `edit_listing.js` and add async swap
- update `edit_listing.html` for thumbnails and swap forms
- add `/swap-mockup` route in new blueprint
- adjust category scanning and swap logic
- add single-mode to `generate_composites.py`
- register new blueprint
- add Codex log

## Testing
- `pip install opencv-python-headless ImageHash`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68858e91a8b0832e8b7c9bcc9c63d4ad