### PR TITLE
Centralize path utils

### DIFF
--- a/CODEX-LOGS/2025-07-28-CODEX-LOG2.md
+++ b/CODEX-LOGS/2025-07-28-CODEX-LOG2.md
@@ -1,0 +1,9 @@
+# Codex Log for Master Task on 2025-07-28
+
+## Summary
+- Centralised listing path logic into `helpers/path_utils.py` to avoid circular imports.
+- Updated `routes/utils.py` and `routes/artwork_routes.py` to import from config and new helper module.
+- Added pytest configuration to restrict discovery and installed required packages for testing.
+- Improved `load_json_file_safe` logging and added missing helper `find_aspect_filename_from_seo_folder`.
+- Optionalised `cv2` import to avoid ImportError when OpenCV unavailable.
+

--- a/helpers/path_utils.py
+++ b/helpers/path_utils.py
@@ -1,0 +1,37 @@
+"""Path utilities for DreamArtMachine.
+
+This module centralises listing path resolution logic so
+other modules can import it without causing circular dependencies.
+"""
+from __future__ import annotations
+from pathlib import Path
+import config
+
+
+def resolve_listing_paths(aspect: str, seo_folder: str, allow_locked: bool = False) -> tuple:
+    """Return folder, listing JSON path and image path for ``seo_folder``.
+
+    Parameters
+    ----------
+    aspect: str
+        Aspect ratio (unused but kept for backward compatibility).
+    seo_folder: str
+        The folder name containing the listing.
+    allow_locked: bool, optional
+        If ``True`` search finalised and locked folders in addition to processed.
+    """
+    slug = seo_folder.replace("LOCKED-", "")
+    roots = [config.PROCESSED_ROOT]
+    if allow_locked:
+        roots += [config.FINALISED_ROOT, config.ARTWORK_VAULT_ROOT]
+
+    for root in roots:
+        folder = root / seo_folder
+        if folder.exists():
+            listing_file = folder / config.FILENAME_TEMPLATES["listing_json"].format(seo_slug=slug)
+            image_file = folder / f"{slug}.jpg"
+            return root, folder, listing_file, image_file
+    raise FileNotFoundError(
+        f"Cannot resolve paths for folder '{seo_folder}' (allow_locked={allow_locked})"
+    )
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths =
+    tests
+    routes


### PR DESCRIPTION
## Summary
- centralize listing path resolver in `helpers.path_utils`
- update route modules to import from `config` and new helper
- improve JSON loader logging and add missing finder helper
- add pytest config for selective discovery

See `CODEX-LOGS/2025-07-28-CODEX-LOG2.md` for details.

------
https://chatgpt.com/codex/tasks/task_e_688726514b38832ea22456fd98e11b4a