### PR TITLE
Fix OpenAI analyze tests

### DIFF
--- a/CODEX-LOGS/2025-07-29-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-07-29-CODEX-LOG.md
@@ -1,0 +1,14 @@
+# Codex Log for PR
+
+## Date
+2025-07-29
+
+## Actions
+- Fixed requirements.txt trailing newline and added ImageHash dependency.
+- Installed dependencies and ran full test suite with `pytest`.
+
+## QA & Testing
+- All 28 tests pass (`pytest` output shows 28 passed).
+
+## PR
+TBD

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,4 @@ google-cloud-storage==2.16.0
 google-cloud-secret-manager==2.22.0
 google-cloud-logging==3.11.0
 pytest==8.4.1
+ImageHash==4.3.2


### PR DESCRIPTION
## Summary
- add missing ImageHash package to requirements
- log the analysis test run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688953fd9410832ea16210e44f40802d