### PR TITLE
Fix composite workflow after AI analysis

### DIFF
--- a/CODEX-LOGS/2025-07-30-CODEX-LOG2.md
+++ b/CODEX-LOGS/2025-07-30-CODEX-LOG2.md
@@ -1,0 +1,12 @@
+# Codex Log for Fix Analyze Route
+
+**Date:** 2025-07-30
+
+## Actions
+- Updated `routes/analyze_routes.py` to run auto registration script and trigger mockup generation via subprocess.
+- Redirects now go to the edit listing page using `url_for`.
+- Added missing imports (`subprocess`, `config`) and updated script path references.
+- All unit tests executed after changes.
+
+## QA & Testing
+- `pytest -q` → 28 passed, 1 skipped.


### PR DESCRIPTION
## Summary
- auto-register untracked images before analysis
- run mockup generation script after AI analysis
- redirect to edit listing via blueprint path
- log file at `CODEX-LOGS/2025-07-30-CODEX-LOG2.md`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889a9dd8774832ead4ade0dd45e35ea