### PR TITLE
fix: robust path handling and json resets

### DIFF
--- a/CODEX-LOGS/2025-08-03-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-08-03-CODEX-LOG.md
@@ -1,0 +1,15 @@
+# Codex Log - 2025-08-03
+
+## Changes
+- Fixed JSON file handling to reset invalid or empty files and updated log messages.
+- Added robust stage resolution utility for artwork directories.
+- Exposed `LOGS_DIR` constant in routes utils for tests.
+- Improved finalised gallery template with dynamic image routing and safe defaults.
+- Updated tests for JSON handling, route crawling, and added stage-resolution coverage.
+
+## Testing
+- `pytest tests/test_analysis_status_file.py tests/test_analyze_api.py tests/test_routes.py`
+- `pytest`
+
+## Notes
+- All tests pass (29 passed, 1 skipped).

--- a/routes/utils.py
+++ b/routes/utils.py
@@ -105,6 +105,12 @@ from helpers.listing_utils import resolve_listing_paths, load_json_file_safe
 Image.MAX_IMAGE_PIXELS = None
 logger = logging.getLogger(__name__)
 
+# Expose a LOGS_DIR constant so tests and other modules can monkeypatch or
+# reference the application's log directory without importing ``config``
+# directly.  Falling back to a temporary path keeps this module safe during
+# isolated unit tests where ``config.LOGS_DIR`` may not exist.
+LOGS_DIR = getattr(config, "LOGS_DIR", Path("/tmp/logs"))
+
 ALLOWED_COLOURS = sorted(config.ETSY_COLOURS.keys())
 ALLOWED_COLOURS_LOWER = {c.lower(): c for c in ALLOWED_COLOURS}
 

--- a/templates/finalised.html
+++ b/templates/finalised.html
@@ -20,9 +20,11 @@
   {% for art in artworks %}
   <div class="final-card">
     <div class="card-thumb">
+      {% set route = 'artwork.locked_image' if art.locked else 'artwork.finalised_image' %}
+      {% set main_path = art.seo_folder ~ '/' ~ (art.main_image or '') %}
       {% if art.main_image %}
-      <a href="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=art.main_image) }}" class="final-img-link" data-img="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=art.main_image) }}">
-        <img src="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=art.main_image) }}" class="card-img-top" alt="{{ art.title }}">
+      <a href="{{ url_for(route, filename=main_path) }}" class="final-img-link" data-img="{{ url_for(route, filename=main_path) }}">
+        <img src="{{ url_for(route, filename=main_path) }}" class="card-img-top" alt="{{ art.title }}">
       </a>
       {% else %}
       <img src="{{ url_for('static', filename='img/no-image.svg') }}" class="card-img-top" alt="No image">
@@ -30,19 +32,20 @@
     </div>
     <div class="card-details">
       <div class="card-title">{{ art.title }}{% if art.locked %} <span class="locked-badge">Locked</span>{% endif %}</div>
-      <div class="desc-snippet" title="{{ art.description }}">
-        {{ art.description[:200] }}{% if art.description|length > 200 %}...{% endif %}
+      <div class="desc-snippet" title="{{ art.description|default('') }}">
+        {{ art.description|default('')|truncate(200) }}
       </div>
-      <div>SKU: {{ art.sku }}</div>
-      <div>Price: {{ art.price }}</div>
-      <div>Colours: {{ art.primary_colour }} / {{ art.secondary_colour }}</div>
-      <div>SEO: {{ art.seo_filename }}</div>
-      <div>Tags: {{ art.tags|join(', ') }}</div>
-      <div>Materials: {{ art.materials|join(', ') }}</div>
+      <div>SKU: {{ art.sku|default('') }}</div>
+      <div>Price: {{ art.price|default('') }}</div>
+      <div>Colours: {{ art.primary_colour|default('') }} / {{ art.secondary_colour|default('') }}</div>
+      <div>SEO: {{ art.seo_filename|default('') }}</div>
+      <div>Tags: {{ art.tags|default([])|join(', ') }}</div>
+      <div>Materials: {{ art.materials|default([])|join(', ') }}</div>
       {% if art.mockups %}
       <div class="mini-mockup-grid">
         {% for m in art.mockups %}
-        <img src="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=m.filename) }}" alt="mockup"/>
+        {% set m_path = art.seo_folder ~ '/' ~ m.filename %}
+        <img src="{{ url_for(route, filename=m_path) }}" alt="mockup"/>
         {% endfor %}
       </div>
       {% endif %}
@@ -51,9 +54,8 @@
         <summary>Image URLs</summary>
         <ul>
           {% for img in art.images %}
-          <li>
-            <a href="{{ url_for('artwork.finalised_image', seo_folder=art.seo_folder, filename=img.split('/')[-1]) }}" target="_blank">/{{ img }}</a>
-          </li>
+          {% set i_path = art.seo_folder ~ '/' ~ img.split('/')[-1] %}
+          <li><a href="{{ url_for(route, filename=i_path) }}" target="_blank">/{{ img }}</a></li>
           {% endfor %}
         </ul>
       </details>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,6 +1,9 @@
+import os
 import re
 from html.parser import HTMLParser
 from pathlib import Path
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
 
 import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- harden JSON loading and reset invalid/empty files
- expose LOGS_DIR for tests and resolve artwork stage dynamically
- improve finalised template path resolution and add path stage tests

## Testing
- `pytest tests/test_analysis_status_file.py tests/test_analyze_api.py tests/test_routes.py`
- `pytest`

## Logs
- [`CODEX-LOGS/2025-08-03-CODEX-LOG.md`](CODEX-LOGS/2025-08-03-CODEX-LOG.md)


------
https://chatgpt.com/codex/tasks/task_e_688ee4e4381c832e806a7a47515504e6