### PR TITLE
feat: add Sellbrite export table and lock-in workflow

### DIFF
--- a/CODEX-LOGS/2025-08-03-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-08-03-CODEX-LOG.md
@@ -1,15 +1,17 @@
-# Codex Log - 2025-08-03
+# Codex Log for Dynamic Sellbrite Export Integration
 
-## Changes
-- Fixed JSON file handling to reset invalid or empty files and updated log messages.
-- Added robust stage resolution utility for artwork directories.
-- Exposed `LOGS_DIR` constant in routes utils for tests.
-- Improved finalised gallery template with dynamic image routing and safe defaults.
-- Updated tests for JSON handling, route crawling, and added stage-resolution coverage.
+**Date:** 2025-08-03
 
-## Testing
-- `pytest tests/test_analysis_status_file.py tests/test_analyze_api.py tests/test_routes.py`
-- `pytest`
+## Actions
+- Implemented `generate_public_image_urls` utility to produce absolute image links for all artwork stages.
+- Expanded `update_listing_paths` to update filesystem paths and corresponding public URLs.
+- Revised `edit_listing` workflow to inject public URLs, added Sellbrite export details table, and replaced finalisation with a "Lock It In" action.
+- Added `/lock-it-in/<seo_folder>` route and updated locking logic to regenerate image URLs when moving stages.
+- Updated front-end script to refresh export table URLs and added unit tests for URL generation.
+
+## QA & Testing
+- `pytest` – 31 passed, 1 skipped.
 
 ## Notes
-- All tests pass (29 passed, 1 skipped).
+- No major issues encountered; verified URL generation across stages.
+

--- a/static/js/edit_listing.js
+++ b/static/js/edit_listing.js
@@ -132,7 +132,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await response.json();
         if (!response.ok) throw new Error(data.message || 'Server error');
         
-        document.getElementById('images-input').value = data.images.join('\n');
+        const joined = data.images.join('\n');
+        document.getElementById('images-input').value = joined;
+        const publicBox = document.getElementById('public-image-urls');
+        if (publicBox) publicBox.value = joined;
       } catch (error) {
         alert(`Error updating image links: ${error.message}`);
       } finally {

--- a/templates/edit_listing.html
+++ b/templates/edit_listing.html
@@ -225,8 +225,8 @@
         {% endif %}
 
         {% if not finalised %}
-          <form method="post" action="{{ url_for('artwork.finalise_artwork', aspect=aspect, filename=filename) }}" class="action-form">
-            <button type="submit" class="btn btn-primary wide-btn">Finalise Listing</button>
+          <form method="post" action="{{ url_for('artwork.lock_it_in', seo_folder=seo_folder) }}" class="action-form">
+            <button type="submit" class="btn btn-primary wide-btn">🔒 Lock It In</button>
           </form>
         {% endif %}
 
@@ -245,26 +245,28 @@
         <button form="edit-form" type="submit" name="action" value="delete" class="btn btn-danger wide-btn" onclick="return confirm('Delete this artwork and all files? This cannot be undone.');" {% if not editable %}disabled{% endif %}>Delete Artwork</button>
       </div>
 
-      {# OpenAI Debug Info Table #}
-      {% if openai_analysis %}
-        <div class="openai-details">
-          <h3>OpenAI Analysis Details</h3>
-          <table class="openai-analysis-table">
-            <tbody>
-              <tr><th>Original File</th><td>{{ openai_analysis.original_file }}</td></tr>
-              <tr><th>Optimized File</th><td>{{ openai_analysis.optimized_file }}</td></tr>
-              <tr><th>Size</th><td>{{ openai_analysis.size_mb }} MB ({{ openai_analysis.size_bytes }} bytes)</td></tr>
-              <tr><th>Dimensions</th><td>{{ openai_analysis.dimensions }}</td></tr>
-              <tr><th>Time Sent</th><td>{{ openai_analysis.time_sent }}</td></tr>
-              <tr><th>Time Responded</th><td>{{ openai_analysis.time_responded }}</td></tr>
-              <tr><th>Duration</th><td>{{ openai_analysis.duration_sec }} s</td></tr>
-              <tr><th>Status</th><td>{{ openai_analysis.status }}</td></tr>
-              <tr><th>API Response</th><td>{{ openai_analysis.api_response }}</td></tr>
-            </tbody>
-          </table>
-        </div>
-      {% endif %}
     </div>
+  </div>
+
+  {# ---------------------------------------------------------
+     SECTION 3.3: SELLBRITE EXPORT DETAILS TABLE
+  --------------------------------------------------------- #}
+  <div class="export-details-table">
+    <h2>Sellbrite Export Details</h2>
+    <table class="full-width-table">
+      <tr><th>Title</th><td>{{ artwork.title }}</td></tr>
+      <tr><th>SKU</th><td>{{ artwork.sku }}</td></tr>
+      <tr><th>SEO Slug</th><td>{{ seo_folder }}</td></tr>
+      <tr><th>Dimensions</th><td>{{ artwork.dimensions }}</td></tr>
+      <tr><th>Size</th><td>{{ artwork.size }}</td></tr>
+      <tr><th>Tags</th><td>{{ artwork.tags }}</td></tr>
+      <tr><th>Materials</th><td>{{ artwork.materials }}</td></tr>
+      <tr><th>Colours</th><td>{{ artwork.primary_colour }}{% if artwork.secondary_colour %}, {{ artwork.secondary_colour }}{% endif %}</td></tr>
+      <tr>
+        <th>Public Image URLs</th>
+        <td><textarea id="public-image-urls" rows="10" readonly>{{ public_image_urls | join('\n') }}</textarea></td>
+      </tr>
+    </table>
   </div>
 
   {# -------------------------------

--- a/tests/test_public_urls.py
+++ b/tests/test_public_urls.py
@@ -1,0 +1,41 @@
+import config
+from helpers.listing_utils import generate_public_image_urls
+
+def setup_paths(tmp_path, monkeypatch):
+    base = tmp_path / "app"
+    base.mkdir()
+    monkeypatch.setattr(config, "BASE_DIR", base)
+    monkeypatch.setattr(config, "BASE_URL", "http://example.com")
+    unanalysed = base / "art-processing" / "unanalysed-artwork"
+    processed = base / "art-processing" / "processed-artwork"
+    finalised = base / "art-processing" / "finalised-artwork"
+    vault = base / "art-processing" / "artwork-vault"
+    for p in (unanalysed, processed, finalised, vault):
+        p.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(config, "UNANALYSED_ROOT", unanalysed)
+    monkeypatch.setattr(config, "PROCESSED_ROOT", processed)
+    monkeypatch.setattr(config, "FINALISED_ROOT", finalised)
+    monkeypatch.setattr(config, "ARTWORK_VAULT_ROOT", vault)
+    monkeypatch.setattr(config, "UNANALYSED_IMG_URL_PREFIX", "unanalysed-img")
+    monkeypatch.setattr(config, "PROCESSED_URL_PATH", f"static/{processed.relative_to(base).as_posix()}")
+    monkeypatch.setattr(config, "FINALISED_URL_PATH", f"static/{finalised.relative_to(base).as_posix()}")
+    monkeypatch.setattr(config, "LOCKED_URL_PATH", f"static/{vault.relative_to(base).as_posix()}")
+    return processed, vault
+
+def test_generate_public_image_urls_processed(tmp_path, monkeypatch):
+    processed, _ = setup_paths(tmp_path, monkeypatch)
+    folder = processed / "test-art"
+    folder.mkdir()
+    (folder / "test-art-1.jpg").write_bytes(b"a")
+    urls = generate_public_image_urls("test-art", "processed")
+    expected = f"http://example.com/static/{processed.relative_to(config.BASE_DIR).as_posix()}/test-art/test-art-1.jpg"
+    assert urls == [expected]
+
+def test_generate_public_image_urls_vault(tmp_path, monkeypatch):
+    _, vault = setup_paths(tmp_path, monkeypatch)
+    folder = vault / "LOCKED-test-art"
+    folder.mkdir()
+    (folder / "LOCKED-test-art.jpg").write_bytes(b"a")
+    urls = generate_public_image_urls("test-art", "vault")
+    expected = f"http://example.com/static/{vault.relative_to(config.BASE_DIR).as_posix()}/LOCKED-test-art/LOCKED-test-art.jpg"
+    assert urls == [expected]


### PR DESCRIPTION
## Summary
- generate absolute image URLs for each artwork stage
- streamline finalisation with `lock_it_in` and display Sellbrite export details
- keep listing path updates in sync with public URLs

## Testing
- `pytest`

## Log
- `/CODEX-LOGS/2025-08-03-CODEX-LOG.md`


------
https://chatgpt.com/codex/tasks/task_e_688f0d6dc188832ebbbbc8ed879b0b06