### PR TITLE
Use wsgi factory for Gunicorn service

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,3 @@
+from app import create_app
+
+app = create_app()


### PR DESCRIPTION
## Summary
- add a wsgi entrypoint using `create_app`
- configure gunicorn service to load `wsgi:app`

## Testing
- `sudo systemctl daemon-reexec` *(fails: System has not been booted with systemd as init system)*
- `sudo systemctl daemon-reload` *(fails: System has not been booted with systemd as init system)*
- `sudo systemctl restart gunicorn` *(fails: System has not been booted with systemd as init system)*
- `sudo journalctl -u gunicorn -n 50 --no-pager` *(fails: No journal files were found)*
- `PYTHONPATH=/workspace/art gunicorn --config gunicorn.conf.py --log-file - wsgi:app` *(fails: SyntaxError in routes/artwork_routes.py)*
- `pytest` *(fails: ImportError: cannot import name 'assign_or_get_sku' from 'utils.sku_assigner')*

PATCH-GUNICORN-WSGI-FIX-2025-08-05

------
https://chatgpt.com/codex/tasks/task_e_68919586ea88832e8c90928c96e788a4